### PR TITLE
update find_aligned_clusters + unittest

### DIFF
--- a/src/identifiers/title_page.py
+++ b/src/identifiers/title_page.py
@@ -8,6 +8,9 @@ from src.text_objects import TextLine
 
 logger = logging.getLogger(__name__)
 
+ALIGNED_WORD_RATIO_THRESHOLD = 0.8
+VERTICAL_SPACING_FACTOR = 5.0
+
 
 def identify_title_page(ctx: PageContext, matching_params: dict) -> bool:
     """
@@ -77,7 +80,7 @@ def has_aligned_layout(ctx: PageContext) -> bool:
     clusters = get_all_layout_clusters(ctx.lines, ctx.page_rect.width)
     words = sum(len(line.words) for cluster in clusters for line in cluster)
 
-    return words / len(ctx.words) > 0.8
+    return words / len(ctx.words) > ALIGNED_WORD_RATIO_THRESHOLD
 
 
 def has_large_font_layout(ctx: PageContext) -> bool:
@@ -177,8 +180,17 @@ def find_aligned_clusters(
     threshold: float
 ) -> list[list[TextLine]]:
     """
-    Finds clusters of lines aligned by a given key (e.g. x0, x1, center).
-    Considers only lines with vertical proximity to last line of current cluster.
+     Groups text lines into alignment clusters based on a key function (e.g. x0-position).
+    This function finds clusters of visually aligned lines by comparing each line’s alignment key
+    (e.g. x0, center, x1) and vertical position.
+
+       Parameters:
+        lines (list[TextLine]): List of text lines to cluster.
+        key_func (Callable): Function to extract the alignment key from a line (e.g. lambda l: l.rect.x0).
+        threshold (float): Maximal misalignment between lines for them to be considered aligned.
+
+    Returns:
+        list[list[TextLine]]: List of clusters, each a list of aligned TextLines.
     """
     remaining_lines = set(lines)
     clusters = []
@@ -201,7 +213,7 @@ def find_aligned_clusters(
                 other
                 for other in remaining_lines
                 if abs(key_func(other) - cluster_key) < threshold # limit for how much misaligned other line can be
-                and abs(other.rect.y0 - line.rect.y0) < 5.0 * font_size #limit for how far below other line can lie
+                and abs(other.rect.y0 - line.rect.y0) < VERTICAL_SPACING_FACTOR * font_size #limit for how far below other line can lie
             }
 
             line_queue.extend(close_lines) # add close lines into queue

--- a/tests/test_title_page.py
+++ b/tests/test_title_page.py
@@ -1,6 +1,6 @@
 import pytest
 import pymupdf
-from src.identifiers.title_page import find_aligned_clusters
+from src.identifiers.title_page import find_aligned_clusters, VERTICAL_SPACING_FACTOR
 from src.text_objects import TextLine, TextWord
 
 def x0(line): return line.rect.x0
@@ -12,7 +12,7 @@ def test_x0_cluster():
         TextLine([TextWord(pymupdf.Rect(100, 145, 200, 155), "Line 2",0)]),
         TextLine([TextWord(pymupdf.Rect(100, 190, 200, 200), "Line 3",0)])
     ]
-    clusters = find_aligned_clusters(lines, key_func= lambda l: l.rect.x0, threshold=5)
+    clusters = find_aligned_clusters(lines, key_func= lambda l: l.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 1
     assert len(clusters[0]) == 3
 
@@ -24,7 +24,7 @@ def test_two_x0_clusters():
         TextLine([TextWord(pymupdf.Rect(300, 100, 400, 110), "Line 1 in cluster 2",0)]),
         TextLine([TextWord(pymupdf.Rect(298, 130, 400, 140), "Line 2 in cluster 2",0)]),
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=5)
+    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 2
     for cluster in clusters:
         assert len(cluster) == 2
@@ -36,7 +36,7 @@ def test_transitive_inclusion():
         TextLine([TextWord(pymupdf.Rect(104, 130, 204, 140), "Line B",0)]),  # B
         TextLine([TextWord(pymupdf.Rect(108, 160, 208, 170), "Line C",0)]),  # C
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=5)
+    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 1
     assert len(clusters[0]) == 3
 
@@ -47,7 +47,7 @@ def test_no_clusters_x0():
         TextLine([TextWord(pymupdf.Rect(300, 300, 400, 310), "Line B",0)]),
         TextLine([TextWord(pymupdf.Rect(500, 500, 600, 510), "Line C",0)]),
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=5)
+    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 0
 
 def test_no_cluster_y0():
@@ -57,5 +57,5 @@ def test_no_cluster_y0():
         TextLine([TextWord(pymupdf.Rect(100, 160, 200, 170), "Line B", 0)]), # > 5 * height away
         TextLine([TextWord(pymupdf.Rect(100, 210, 200, 220), "Line C", 0)]), # > 5 * height away
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=5)
+    clusters = find_aligned_clusters(lines, key_func=lambda l: l.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 0


### PR DESCRIPTION
Small PR in which:
- Refactored `find_aligned_clusters()` to support transitive clustering (A → B → C, even if A not aligned with C).
- Added unit tests to cover this scenario.
Metrics of this branch

| Metric        | Text    | Boreprofile | Maps   | Title_Page | Unknown |
|---------------|---------|-------------|--------|------------|---------|
| **F1**        | 66.27%  | 77.30%      | 79.74% | **52.38%** | **63.67%** |
| **Precision** | 59.89%  | 76.83%      | 79.22% | **55.00%** | **68.12%** |
| **Recall**    | 74.17%  | 77.78%      | 80.26% | **50.00%** | **59.77%** |
