### PR TITLE
Feature/assets 674: Deploy API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /models/FastText \
 FROM python:3.13-slim-bookworm AS runtime
 
 ENV FASTTEXT_MODEL_PATH="models/FastText/lid.176.bin"
+ENV TMP_PATH=/tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1-mesa-glx \


### PR DESCRIPTION
Part of https://github.com/swisstopo/swissgeol-assets-suite/issues/674.

Adds a default `TMP_PATH` to `Dockerfile`