### PR TITLE
Detect diagrams

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -322,3 +322,66 @@ title_page:
   it:
     - rapporto
     - progetto
+
+diagram:
+  en:
+    - diagram
+    - curve
+    - distribution
+    - histogram
+    - summation curve
+    - cumulative curve
+    - grading curve
+  de:
+    - kurve
+    - diagramm
+    - kornverteilung
+    - histogramm
+    - summationskurve
+    - körnungslinie
+    - verteilungskurve
+  fr:
+    - diagramme
+    - courbe
+    - distribution
+    - histogramme
+    - courbe de sommation
+    - courbe granulométrique
+  it:
+    - diagramma
+    - curva
+    - distribuzione
+    - istogramma
+    - curva cumulativa
+    - curva granulometrica
+
+units:
+  - m
+  - cm
+  - mm
+  - µm
+  - nm
+  - km
+  - g
+  - kg
+  - mg
+  - t
+  - mol
+  - mol/l
+  - mol/m3
+  - kg/m3
+  - g/cm3
+  - °c
+  - k
+  - pa
+  - kpa
+  - mpa
+  - bar
+  - l
+  - ml
+  - l/s
+  - m/s
+  - s
+  - sec
+  - h
+  - ora

--- a/src/classifiers/baseline_classifier.py
+++ b/src/classifiers/baseline_classifier.py
@@ -5,6 +5,7 @@ import pymupdf
 
 from src.classifiers.classifier_types import Classifier, ClassifierTypes
 from src.identifiers.boreprofile import identify_boreprofile, keywords_in_figure_description
+from src.identifiers.diagram import identify_diagram
 from src.identifiers.map import identify_map
 from src.identifiers.text import identify_text
 from src.identifiers.title_page import identify_title_page
@@ -34,6 +35,9 @@ class RuleBasedClassifier(Classifier):
 
         if self._detect_map(page, context):
             return PageClasses.MAP
+
+        if identify_diagram(context, self.matching_params):
+            return PageClasses.DIAGRAM
 
         if identify_title_page(context, self.matching_params):
             return PageClasses.TITLE_PAGE

--- a/src/identifiers/boreprofile.py
+++ b/src/identifiers/boreprofile.py
@@ -23,10 +23,6 @@ class Entry:
         return f"{self.value}"
 
 
-def is_strictly_increasing(entries: list[Entry]) -> bool:
-    return all(entries[i].value < entries[i + 1].value for i in range(len(entries) - 1))
-
-
 def detect_entries(words: list[TextWord]) -> list[Entry]:
     regex = re.compile(r"^-?\.?([0-9]+(\.[0-9]*)?)[müMN\\.]*$")
     entries = []
@@ -41,11 +37,26 @@ def detect_entries(words: list[TextWord]) -> list[Entry]:
     return entries
 
 
+def is_mostly_increasing(entries: list[Entry], tolerance: float = 0.2) -> bool:
+    """Check if a sequence is mostly increasing.
+
+    Args:
+        entries: list of Entry objects with a .value attribute.
+        tolerance: fraction of allowed violations (default: 0.2 = 20%).
+
+    Returns:
+        True if the sequence is increasing within tolerance.
+    """
+    values = [e.value for e in entries]
+    violations = sum(values[i] >= values[i + 1] for i in range(len(values) - 1))
+    return violations <= tolerance * (len(values) - 1)
+
+
 def create_sidebars(words: list[TextWord]) -> list[list[Entry]]:
     """Create Sidebars from potential entries."""
     entries = detect_entries(words)
     clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10)
-    return [c for c in clusters if len(c) >= 3 and is_strictly_increasing(c)]
+    return [c for c in clusters if len(c) >= 3 and is_mostly_increasing(c)]
 
 
 def identify_boreprofile(ctx: PageContext, matching_params: dict) -> bool:

--- a/src/identifiers/diagram.py
+++ b/src/identifiers/diagram.py
@@ -1,0 +1,107 @@
+import logging
+import math
+import re
+import statistics
+
+from src.identifiers.boreprofile import Entry, detect_entries, is_mostly_increasing
+from src.page_structure import PageContext
+from src.text_objects import cluster_text_elements
+
+logger = logging.getLogger(__name__)
+
+
+def has_units(ctx: PageContext, units: list[str]) -> bool:
+    """Check if TextWords of PageContext contain units.
+
+    We allow for (unit), [unit], with optional spaces inside
+    """
+    for word in ctx.words:
+        text = word.text.lower()
+        for u in units:
+            pattern = r"[\(\[]\s*" + re.escape(u) + r"\s*[\)\]]"
+            if re.search(pattern, text):
+                return True
+    return False
+
+
+def identify_diagram(ctx: PageContext, matching_params: dict) -> bool:
+    """Detect if page contains diagram.
+
+    Check if Page contains horizontal  and vertical numeric scale which has to be almost increasing or decreasing,
+    Checks if Page contains keywords and units (f.e kg/h)
+    """
+    keywords = matching_params["diagram"].get(ctx.language, [])
+    keywords_unit = matching_params["units"]
+
+    has_keyword = any(keyword in word.text.lower() for word in ctx.words for keyword in keywords)
+    has_unit = has_units(ctx, keywords_unit)
+
+    if has_keyword and has_unit:
+        return True
+
+    entries = detect_entries(ctx.words)
+
+    vertical_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10)
+    horizontal_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.y0, tolerance=10)
+
+    y_axis = [c for c in vertical_clusters if len(c) >= 3]
+    x_axis = [c for c in horizontal_clusters if len(c) >= 3]
+
+    def sorted_axis(axis, key):
+        return [sorted(c, key=key) for c in axis]
+
+    y_axis_sorted = sorted_axis(y_axis, key=lambda e: e.rect.y0)
+    x_axis_sorted = sorted_axis(x_axis, key=lambda e: e.rect.x0)
+
+    y_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in y_axis_sorted)
+    x_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in x_axis_sorted)
+
+    return y_ok and x_ok
+
+
+def normalize_direction(values: list[Entry]) -> list:
+    """Ensure values of entries go ascending; reverse if descending, leave otherwise."""
+    if len(values) < 2:
+        return values
+    return values[::-1] if values[0].value > values[-1].value else values
+
+
+##################tried but worse F1 ####################
+def detect_progression(entries: list[Entry]) -> bool:
+    """Check if entries follow an arithmetic progression."""
+    values = sorted(
+        entry.value for entry in entries
+    )  # probably smarter not sort but check if ascending or descending...
+
+    if is_arithmetic_progression(values):
+        return True
+    return is_log_progression(values)
+
+
+def is_arithmetic_progression(values: list) -> bool:
+    if len(values) <= 2:
+        return False
+    diffs = [values[i + 1] - values[i] for i in range(len(values) - 1)]
+    step = round(statistics.median(diffs), 2)
+    if step > 0:
+        first, last = values[0], values[-1]
+        arithmetic_progression = {round(n * step, 2) for n in range(int(first / step), int(last / step) + 1)}
+        score = sum(val in arithmetic_progression for val in values)
+        if score >= 0.8 * len(values):  # tolerate 20% OCR noise
+            return True
+    return False
+
+
+def is_log_progression(values, tol=0.1):
+    if any(v <= 0 for v in values) or len(values) <= 2:
+        return False
+    log_vals = sorted(math.log10(v) for v in values)
+    diffs = [round(log_vals[i + 1] - log_vals[i], 1) for i in range(len(log_vals) - 1)]
+
+    common_steps = [round(math.log10(s), 2) for s in (2, 3, 5, 10)]  # ≈0.3, 0.48, 0.7, 1.0 log10 base
+
+    good = 0
+    for d in diffs:
+        if any(abs(d - cs) <= tol for cs in common_steps):
+            good += 1
+    return good >= 0.8 * len(diffs)

--- a/src/identifiers/diagram.py
+++ b/src/identifiers/diagram.py
@@ -1,7 +1,6 @@
 import logging
-import math
 import re
-import statistics
+from collections.abc import Callable
 
 from src.identifiers.boreprofile import Entry, detect_entries, is_mostly_increasing
 from src.page_structure import PageContext
@@ -44,17 +43,17 @@ def identify_diagram(ctx: PageContext, matching_params: dict) -> bool:
     vertical_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10)
     horizontal_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.y0, tolerance=10)
 
-    y_axis = [c for c in vertical_clusters if len(c) >= 3]
-    x_axis = [c for c in horizontal_clusters if len(c) >= 3]
+    def is_true_axis(clusters: list[list[Entry]], key: Callable) -> bool:
+        for cluster in clusters:
+            if len(cluster) < 3:
+                continue
+            axis = sorted(cluster, key=key)
+            if is_mostly_increasing(normalize_direction(axis)):
+                return True
+        return False
 
-    def sorted_axis(axis, key):
-        return [sorted(c, key=key) for c in axis]
-
-    y_axis_sorted = sorted_axis(y_axis, key=lambda e: e.rect.y0)
-    x_axis_sorted = sorted_axis(x_axis, key=lambda e: e.rect.x0)
-
-    y_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in y_axis_sorted)
-    x_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in x_axis_sorted)
+    y_ok = is_true_axis(vertical_clusters, key=lambda e: e.rect.y0)
+    x_ok = is_true_axis(horizontal_clusters, key=lambda e: e.rect.x0)
 
     return y_ok and x_ok
 
@@ -64,44 +63,3 @@ def normalize_direction(values: list[Entry]) -> list:
     if len(values) < 2:
         return values
     return values[::-1] if values[0].value > values[-1].value else values
-
-
-##################tried but worse F1 ####################
-def detect_progression(entries: list[Entry]) -> bool:
-    """Check if entries follow an arithmetic progression."""
-    values = sorted(
-        entry.value for entry in entries
-    )  # probably smarter not sort but check if ascending or descending...
-
-    if is_arithmetic_progression(values):
-        return True
-    return is_log_progression(values)
-
-
-def is_arithmetic_progression(values: list) -> bool:
-    if len(values) <= 2:
-        return False
-    diffs = [values[i + 1] - values[i] for i in range(len(values) - 1)]
-    step = round(statistics.median(diffs), 2)
-    if step > 0:
-        first, last = values[0], values[-1]
-        arithmetic_progression = {round(n * step, 2) for n in range(int(first / step), int(last / step) + 1)}
-        score = sum(val in arithmetic_progression for val in values)
-        if score >= 0.8 * len(values):  # tolerate 20% OCR noise
-            return True
-    return False
-
-
-def is_log_progression(values, tol=0.1):
-    if any(v <= 0 for v in values) or len(values) <= 2:
-        return False
-    log_vals = sorted(math.log10(v) for v in values)
-    diffs = [round(log_vals[i + 1] - log_vals[i], 1) for i in range(len(log_vals) - 1)]
-
-    common_steps = [round(math.log10(s), 2) for s in (2, 3, 5, 10)]  # ≈0.3, 0.48, 0.7, 1.0 log10 base
-
-    good = 0
-    for d in diffs:
-        if any(abs(d - cs) <= tol for cs in common_steps):
-            good += 1
-    return good >= 0.8 * len(diffs)


### PR DESCRIPTION
This pull request introduces logic for detecting diagrams. The diagram detection is based on keyword matching and identifying x and y axis scales. 

### Diagram detection

* Added a new `identify_diagram` to detect diagram pages based on keywords, units, and the presence of numeric axes. Numeric axis: identifed via clustering numeric entries on x and y position, values have to be mostly in or decreasing to be considered a scale. (via `is_mostly_increasing` function)
* Updated `config/matching_params.yml` to add `diagram` keywords in multiple languages and a list of units.
### sidebar detection
* Replaced the strict (`is_strictly_increasing`) with a more tolerant `is_mostly_increasing` function in `src/identifiers/boreprofile.py`, which allows up to 20% violations when determining if a sequence is mostly increasing. This makes boreprofile detection more robust to noise.

|Metric | text | boreprofile | map | geo_profile | title_page | diagram | table | unknown | Macro Avg
|-- | -- | -- | -- | -- | -- | -- | -- | -- | --
|F1 Score (%) | 65.00 | 77.77 | 73.07 | 0.00 | 48.78 | 0.55 | 0.00 | 24.66 | 43.04

Currently detection of diagrams does not leverage geometric lines, which might improve the scores. This could further be investigated, also the detection of table like structures (as in the boreholes repository).
