### PR TITLE
Detect diagrams draft

### DIFF
--- a/src/identifiers/diagram.py
+++ b/src/identifiers/diagram.py
@@ -38,8 +38,7 @@ def identify_diagram(ctx: PageContext, matching_params: dict, axis_tolerance: in
 
     words_lower = (word.text.lower() for word in ctx.words)
     has_keyword = any(key in word for word in words_lower for key in keywords)
-    if has_keyword and has_units(ctx, units_cfg):
-        return True
+    has_unit = has_units(ctx, units_cfg)
 
     entries = detect_entries(ctx.words)
 
@@ -49,9 +48,8 @@ def identify_diagram(ctx: PageContext, matching_params: dict, axis_tolerance: in
     y_mono, y_prog = axis_checks(vertical_clusters, sort_key=lambda e: e.rect.y0)
     x_mono, x_prog = axis_checks(horizontal_clusters, sort_key=lambda e: e.rect.x0)
 
-    if y_mono and x_mono:
-        return True  #  both axes look like ordered scales
-    return y_prog or x_prog  # at least one axis shows numeric progression
+    votes = sum([has_keyword, has_unit, y_mono, x_mono, y_prog, x_prog])
+    return votes >= 3
 
 
 def axis_checks(clusters: list, sort_key: Callable) -> tuple[bool, bool]:

--- a/src/identifiers/diagram.py
+++ b/src/identifiers/diagram.py
@@ -2,6 +2,7 @@ import logging
 import math
 import re
 import statistics
+from collections.abc import Callable
 
 from src.identifiers.boreprofile import Entry, detect_entries, is_mostly_increasing
 from src.page_structure import PageContext
@@ -24,39 +25,65 @@ def has_units(ctx: PageContext, units: list[str]) -> bool:
     return False
 
 
-def identify_diagram(ctx: PageContext, matching_params: dict) -> bool:
-    """Detect if page contains diagram.
+def identify_diagram(ctx: PageContext, matching_params: dict, axis_tolerance: int = 10) -> bool:
+    """Determines whether a page contains a diagram based on keywords, units, and axis detection.
 
-    Check if Page contains horizontal  and vertical numeric scale which has to be almost increasing or decreasing,
-    Checks if Page contains keywords and units (f.e kg/h)
+    Detection logic:
+    - If a diagram keyword (language-specific) and a unit are present on the page, returns True.
+    - Otherwise, attempts to detect both x- and y-axes by clustering numbers based on their positions
+    - Returns True if both axes appear to be ordered scales, or if at least one axis shows numeric progression.
     """
-    keywords = matching_params["diagram"].get(ctx.language, [])
-    keywords_unit = matching_params["units"]
+    keywords = (matching_params.get("diagram", {}) or {}).get(ctx.language, []) or []
+    units_cfg = matching_params.get("units", [])
 
-    has_keyword = any(keyword in word.text.lower() for word in ctx.words for keyword in keywords)
-    has_unit = has_units(ctx, keywords_unit)
-
-    if has_keyword and has_unit:
+    words_lower = (word.text.lower() for word in ctx.words)
+    has_keyword = any(key in word for word in words_lower for key in keywords)
+    if has_keyword and has_units(ctx, units_cfg):
         return True
 
     entries = detect_entries(ctx.words)
 
-    vertical_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10)
-    horizontal_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.y0, tolerance=10)
+    vertical_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=axis_tolerance)
+    horizontal_clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.y0, tolerance=axis_tolerance)
 
-    y_axis = [c for c in vertical_clusters if len(c) >= 3]
-    x_axis = [c for c in horizontal_clusters if len(c) >= 3]
+    y_mono, y_prog = axis_checks(vertical_clusters, sort_key=lambda e: e.rect.y0)
+    x_mono, x_prog = axis_checks(horizontal_clusters, sort_key=lambda e: e.rect.x0)
 
-    def sorted_axis(axis, key):
-        return [sorted(c, key=key) for c in axis]
+    if y_mono and x_mono:
+        return True  #  both axes look like ordered scales
+    return y_prog or x_prog  # at least one axis shows numeric progression
 
-    y_axis_sorted = sorted_axis(y_axis, key=lambda e: e.rect.y0)
-    x_axis_sorted = sorted_axis(x_axis, key=lambda e: e.rect.x0)
 
-    y_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in y_axis_sorted)
-    x_ok = any(is_mostly_increasing(normalize_direction(axis)) for axis in x_axis_sorted)
+def axis_checks(clusters: list, sort_key: Callable) -> tuple[bool, bool]:
+    """Checks clusters of values for monotonicity and numeric progression.
 
-    return y_ok and x_ok
+    Args:
+        clusters: A list of clusters, where each cluster is a sequence of values.
+        sort_key: Function used to sort the values within each cluster.
+
+    Returns:
+        tuple[bool, bool]:
+            - The first element is True if any cluster is mostly increasing.
+            - The second element is True if any cluster shows a valid numeric progression.
+    """
+    any_monotone = False
+    any_progression = False
+
+    for c in clusters:
+        if len(c) < 3:
+            continue
+        axis = sorted(c, key=sort_key)
+
+        mono = is_mostly_increasing(normalize_direction(axis))
+        prog = detect_progression(axis)
+
+        any_monotone |= mono
+        any_progression |= prog
+
+        if any_monotone and any_progression:
+            break
+
+    return any_monotone, any_progression
 
 
 def normalize_direction(values: list[Entry]) -> list:
@@ -66,42 +93,46 @@ def normalize_direction(values: list[Entry]) -> list:
     return values[::-1] if values[0].value > values[-1].value else values
 
 
-##################tried but worse F1 ####################
 def detect_progression(entries: list[Entry]) -> bool:
-    """Check if entries follow an arithmetic progression."""
-    values = sorted(
-        entry.value for entry in entries
-    )  # probably smarter not sort but check if ascending or descending...
+    """Check if entries follow an arithmetic or log progression."""
+    values = normalize_direction(entries)  # flip list if descending
+    values = [value.value for value in values]
 
-    if is_arithmetic_progression(values):
-        return True
-    return is_log_progression(values)
+    return is_arithmetic_progression(values) or is_log_progression(values)
 
 
-def is_arithmetic_progression(values: list) -> bool:
+def is_arithmetic_progression(
+    values: list[float],
+    frac_ok: float = 0.8,
+    abs_tol: float = 0.25,
+) -> bool:
+    """Checks if values approximately follow almost an arithmetic progression.
+
+    values: values of the potential arithmetic progression.
+    frac_ok: fraction of steps that must match the median (e.g. 0.8 allows some OCR noise).
+    abs_tol: minimum absolute tolerance so small steps survive rounding/jitter. .
+    """
     if len(values) <= 2:
         return False
-    diffs = [values[i + 1] - values[i] for i in range(len(values) - 1)]
+    diffs = [b - a for a, b in zip(values, values[1:], strict=False)]
     step = round(statistics.median(diffs), 2)
-    if step > 0:
-        first, last = values[0], values[-1]
-        arithmetic_progression = {round(n * step, 2) for n in range(int(first / step), int(last / step) + 1)}
-        score = sum(val in arithmetic_progression for val in values)
-        if score >= 0.8 * len(values):  # tolerate 20% OCR noise
-            return True
-    return False
-
-
-def is_log_progression(values, tol=0.1):
-    if any(v <= 0 for v in values) or len(values) <= 2:
+    # has to be a meaningful positive step
+    if step <= 0:
         return False
-    log_vals = sorted(math.log10(v) for v in values)
-    diffs = [round(log_vals[i + 1] - log_vals[i], 1) for i in range(len(log_vals) - 1)]
 
-    common_steps = [round(math.log10(s), 2) for s in (2, 3, 5, 10)]  # ≈0.3, 0.48, 0.7, 1.0 log10 base
+    same_steps = sum(1 for diff in diffs if math.isclose(diff, step, abs_tol=abs_tol))
+    return same_steps >= frac_ok * len(diffs)
 
+
+def is_log_progression(values: list, tol: float = 0.1) -> bool:
+    """Checks if values are a log10 based progression."""
+    if any(v <= 0 for v in values) or len(values) <= 2:  ## log never negative
+        return False
+    log_vals = [math.log10(v) for v in values]
+    diffs = [b - a for a, b in zip(log_vals, log_vals[1:], strict=False)]
+    common_steps = (math.log10(2), math.log10(3), math.log10(5), 1.0)
     good = 0
-    for d in diffs:
-        if any(abs(d - cs) <= tol for cs in common_steps):
+    for diff in diffs:
+        if any(abs(diff - common_step) <= tol for common_step in common_steps):
             good += 1
     return good >= 0.8 * len(diffs)

--- a/src/identifiers/diagram.py
+++ b/src/identifiers/diagram.py
@@ -33,10 +33,10 @@ def identify_diagram(ctx: PageContext, matching_params: dict, axis_tolerance: in
     - Otherwise, attempts to detect both x- and y-axes by clustering numbers based on their positions
     - Returns True if both axes appear to be ordered scales, or if at least one axis shows numeric progression.
     """
-    keywords = (matching_params.get("diagram", {}) or {}).get(ctx.language, []) or []
+    keywords = matching_params.get("diagram", {}).get(ctx.language, [])
     units_cfg = matching_params.get("units", [])
 
-    words_lower = (word.text.lower() for word in ctx.words)
+    words_lower = [word.text.lower() for word in ctx.words]
     has_keyword = any(key in word for word in words_lower for key in keywords)
     has_unit = has_units(ctx, units_cfg)
 
@@ -84,7 +84,7 @@ def axis_checks(clusters: list, sort_key: Callable) -> tuple[bool, bool]:
     return any_monotone, any_progression
 
 
-def normalize_direction(values: list[Entry]) -> list:
+def normalize_direction(values: list[Entry]) -> list[Entry]:
     """Ensure values of entries go ascending; reverse if descending, leave otherwise."""
     if len(values) < 2:
         return values
@@ -108,7 +108,7 @@ def is_arithmetic_progression(
 
     values: values of the potential arithmetic progression.
     frac_ok: fraction of steps that must match the median (e.g. 0.8 allows some OCR noise).
-    abs_tol: minimum absolute tolerance so small steps survive rounding/jitter. .
+    abs_tol: minimum absolute tolerance so small steps survive rounding/jitter.
     """
     if len(values) <= 2:
         return False
@@ -124,7 +124,7 @@ def is_arithmetic_progression(
 
 def is_log_progression(values: list, tol: float = 0.1) -> bool:
     """Checks if values are a log10 based progression."""
-    if any(v <= 0 for v in values) or len(values) <= 2:  ## log never negative
+    if any(v <= 0 for v in values) or len(values) <= 2:  # log requires positive values
         return False
     log_vals = [math.log10(v) for v in values]
     diffs = [b - a for a, b in zip(log_vals, log_vals[1:], strict=False)]


### PR DESCRIPTION
This draft builds on #46 and experiments with extending the diagram detection logic in src/identifiers/diagram.py.

The `identify_diagram` function uses a voting system based on keywords, units, and axis progression checks, where the axis detection is includes a new `axis_checks` function, which checks for both monotonicity and numeric progression in clusters of entries.

However it introduces more code without improving the F1 scores compared to the latest version in the other branch. We probably do not want to merge this? But the arithmetic checks might come in handy as additional features for the treebased model training?

Introduces an axis_checks helper that evaluates clusters for both monotonicity and numeric progression. It updates identify_diagram to use a voting system across:
- diagram keywords
- units
- y-axis and x-axis monotonicity
- y-axis and x-axis numeric progression (new)

However, F1 scores are not improved compared to the latest implementation in the other branch and the code increases complexity. We likely do not want to merge this, however the progression logic might still be valuable as features for tree-based models.

For diagram
Branch|F1 Score| Precision|Recall
|--|--|--|--
detect-diagram|**62.22**|**60.87**|**63.64**
detect-diagram-draft|**60.47**|**61.90**|**59.09**

|Metric | text | boreprofile | map | geo_profile | title_page | diagram | table | unknown | Macro Avg
|-- | -- | -- | -- | -- | -- | -- | -- | -- | --
|F1 Score  | 65.00 | 77.77 | 73.07 | 0.00 | 48.78 | **62.22** | 0.00 | **26.47** | **44.16**
|F1 Score draft | 65.00 | 77.77 | 73.07 | 0.00 | 48.78 | **60.47** | 0.00 | **25.71** | **43.85**

