### PR TITLE
table detection via word positioning

### DIFF
--- a/src/bounding_box.py
+++ b/src/bounding_box.py
@@ -16,6 +16,16 @@ def merge_bounding_boxes(rects):
     return pymupdf.Rect(x0, y0, x1, y1)
 
 
+def _x_center(rect: pymupdf.Rect) -> float:
+    """Finds middle x position of a rectangle."""
+    return 0.5 * (rect.x0 + rect.x1)
+
+
+def _y_center(rect: pymupdf.Rect) -> float:
+    """Finds middle y position of a rectangle."""
+    return 0.5 * (rect.y0 + rect.y1)
+
+
 def is_line_below_box(line_rect: pymupdf.Rect, image_rect: pymupdf.Rect) -> bool:
     """Determines whether a text line rect is directly below an image rect and horizontally aligned.
 

--- a/src/classifiers/baseline_classifier.py
+++ b/src/classifiers/baseline_classifier.py
@@ -9,6 +9,7 @@ from src.classifiers.classifier_types import Classifier, ClassifierTypes
 from src.identifiers.boreprofile import identify_boreprofile, keywords_in_figure_description
 from src.identifiers.geo_profile import identify_geo_profile
 from src.identifiers.map import identify_map
+from src.identifiers.table import identify_table
 from src.identifiers.text import identify_text
 from src.identifiers.title_page import identify_title_page
 from src.line_detection import extract_geometric_lines
@@ -42,6 +43,9 @@ class RuleBasedClassifier(Classifier):
 
         if self._detect_map(page, context):
             return PageClasses.MAP
+
+        if identify_table(context):
+            return PageClasses.TABLE
 
         if identify_title_page(context, self.matching_params):
             return PageClasses.TITLE_PAGE

--- a/src/identifiers/boreprofile.py
+++ b/src/identifiers/boreprofile.py
@@ -44,7 +44,7 @@ def detect_entries(words: list[TextWord]) -> list[Entry]:
 def create_sidebars(words: list[TextWord]) -> list[list[Entry]]:
     """Create Sidebars from potential entries."""
     entries = detect_entries(words)
-    clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10)
+    clusters = cluster_text_elements(entries, key_fn=lambda e: e.rect.x0, tolerance=10.0)
     return [c for c in clusters if len(c) >= 3 and is_strictly_increasing(c)]
 
 

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -1,8 +1,11 @@
+import numpy as np
+import pymupdf
+
 from src.page_structure import PageContext
-from src.text_objects import TextColumn, TextTable, TextWord, cluster_connected_components, cluster_text_elements
+from src.text_objects import TextColumn, TextTable, TextWord, cluster_connected_components
 
 
-def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float = 0.5) -> bool:
+def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float = 0.3) -> bool:
     """Identifies whether a page is likely to contain a table based on text alignment.
 
     Factors include:
@@ -19,44 +22,113 @@ def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float 
     return any(table.text_coverage(ctx.words) > min_coverage for table in good_text_tables)
 
 
-def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 3) -> list[TextTable]:
+def detect_text_table(
+    ctx: PageContext, gap_factor: float = 4.0, x_tol: float = 2.0, min_cols: int = 3, max_noise: float = 1.5
+) -> list[TextTable]:
     """Detects and returns text tables with minimum 3 columns on a page based on aligned text columns.
 
     Args:
         ctx: PageContext of the page to analyze.
+        gap_factor: Factor by which mean vertical word gap will be multiplied
+            To get maximal vertical gap with which column will be constructed.
+            This allows adapting to different line spacings on the page.
         x_tol: Tolerance for x0 alignment of words to form columns (in px).
         min_cols: Minimum number of columns for a valid table.
+        max_noise: Maximal noise (overlapping non-column words) a column is allowed to have to be considered valid.
 
     Returns:
         List of detected TextTables.
     """
-    cols = make_text_columns(ctx.words, x_tol=x_tol)
+    # adaptive vertical cap from page content
+    word_gap = _median_line_gap(ctx.words)
+    max_vert_gap = gap_factor * word_gap
+
+    cols = make_text_columns(ctx.words, x_tol=x_tol, max_vertical_gap=max_vert_gap)
     if len(cols) < min_cols:
         return []
 
-    tables = make_text_tables(cols)
+    valid_cols = [col for col in cols if col.noise(ctx.words) < max_noise]
+    tables = make_text_tables(valid_cols)
+
     return [table for table in tables if len(table.columns) >= min_cols]
 
 
-def make_text_columns(words: list[TextWord], x_tol: float = 2.0, min_words: int = 3) -> list[TextColumn]:
+def make_text_columns(
+    words: list[TextWord],
+    max_vertical_gap: float,
+    x_tol: float = 2.0,
+    min_words: int = 3,
+    overlap_min: float = 0.8,
+) -> list[TextColumn]:
     """Build TextColumns based on x0 alignment of TextWords.
 
     Args:
         words: List of TextWords on the page.
+        max_vertical_gap: max vertical distance allowed between word within one column
         x_tol: Tolerance for x0 alignment (in px).
         min_words: Minimum number of words in a column to be considered valid.
+        overlap_min: Minimum horizontal overlap ratio of the words' bounding boxes.
 
     Returns:
         List of detected TextColumns.
     """
-    clusters = cluster_text_elements(words, key_fn=lambda w: w.rect.x0, tolerance=x_tol)
+    if not words:
+        return []
+
+    def pred(a, b):
+        return _belongs_to_same_column(
+            a,
+            b,
+            x_tol=x_tol,
+            overlap_min=overlap_min,
+            max_vert_gap=max_vertical_gap,
+        )
+
+    clusters = cluster_connected_components(words, pred)
     return [TextColumn(col) for col in clusters if len(col) >= min_words]
+
+
+def _belongs_to_same_column(
+    w1: TextWord,
+    w2: TextWord,
+    x_tol: float,
+    overlap_min: float,
+    max_vert_gap: float,
+) -> bool:
+    """Checks if two words can belong to the sam TextColumn.
+
+    Args:
+        w1: First TextWord.
+        w2: Second TextWord.
+        x_tol: x distance tolerance between the x centers of the words.
+        overlap_min: minimum horizontal overlap ratio of the words' bounding boxes.
+        max_vert_gap: maximum vertical distance between the words.
+
+    Returns:
+        True if the two words belong to the same column.
+
+    Words belong to the same column:
+    - if their x centers are closer together than the x tolerance threshold.
+    - if their bounding boxes overlap more than overlap_min.
+    - if their vertical distance to each other is smaller than max_vert_gap
+    """
+    r1, r2 = w1.rect, w2.rect
+
+    # 1) Similar horizontal anchor
+    x_close = round(abs(_x_center(r1) - _x_center(r2))) <= x_tol
+    x_overlap_ok = _hproj_overlap_ratio(r1, r2) >= overlap_min
+    x_ok = x_close and x_overlap_ok
+
+    if not x_ok:
+        return False
+
+    # 2) Vertically adjacent
+    vertical_gap = _vertical_gap(r1, r2)
+    return vertical_gap <= max_vert_gap
 
 
 def make_text_tables(cols: list[TextColumn]) -> list[TextTable]:
     """Groups TextColumns into TextTables based on alignment.
-
-    Uses a simple BFS approach.
 
     Args:
         cols: List of TextColumns to group into tables.
@@ -105,3 +177,35 @@ def _columns_align(
     h_inter = max(0.0, x1 - x0)
     h_ratio = h_inter / max(1e-6, min(rect1.width, rect2.width))
     return h_ratio <= max_horizontal_overlap
+
+
+def _median_line_gap(words: list[TextWord]) -> float:
+    """Rough line spacing estimate from nearest vertical neighbors."""
+    if len(words) < 2:
+        return 20.0
+    ys = sorted((w.rect.y0 + w.rect.y1) / 2.0 for w in words)  # baselines
+    gaps = [ys[i + 1] - ys[i] for i in range(len(ys) - 1) if ys[i + 1] > ys[i]]
+    return max(10.0, float(np.median(gaps))) if gaps else 20.0
+
+
+def _x_center(rect: pymupdf.Rect) -> float:
+    """Finds middle x position of a rectangle."""
+    return 0.5 * (rect.x0 + rect.x1)
+
+
+def _hproj_overlap_ratio(a: pymupdf.Rect, b: pymupdf.Rect) -> float:
+    """Horizontal overlap ratio relative to the smaller width."""
+    left = max(a.x0, b.x0)
+    right = min(a.x1, b.x1)
+    overlap = max(0.0, right - left)
+    denom = max(1e-6, min(a.x1 - a.x0, b.x1 - b.x0))
+    return overlap / denom
+
+
+def _vertical_gap(a: pymupdf.Rect, b: pymupdf.Rect) -> float:
+    """Positive vertical distance between boxes if they don't overlap; 0 if they overlap."""
+    if a.y1 < b.y0:
+        return b.y0 - a.y1
+    if b.y1 < a.y0:
+        return a.y0 - b.y1
+    return 0.0

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -1,0 +1,129 @@
+from src.page_structure import PageContext
+from src.text_objects import TextColumn, TextTable, TextWord, cluster_text_elements
+
+
+def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float = 0.5) -> bool:
+    """Identifies whether a page is likely to contain a table based on text alignment.
+
+    Factors include:
+    - Presence of text tables
+    - Confidence of detected text tables based on row alignment
+    - Text coverage of detected tables in relation to all text on the page
+    """
+    text_table = detect_text_table(ctx)
+    if not text_table:
+        return False
+
+    good_text_tables = [table for table in text_table if table.confidence >= min_conf]
+
+    return any(table.text_coverage(ctx.words) > min_coverage for table in good_text_tables)
+
+
+def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 2) -> list[TextTable]:
+    """Detects and returns text tables with minimum 3 columns on a page based on aligned text columns.
+
+    Args:
+        ctx: PageContext of the page to analyze.
+        x_tol: Tolerance for x0 alignment of words to form columns (in px).
+        min_cols: Minimum number of columns for a valid table.
+
+    Returns:
+        List of detected TextTables.
+    """
+    cols = make_text_columns(ctx.words, x_tol=x_tol)
+    if len(cols) < min_cols:
+        return []
+
+    tables = make_text_tables(cols)
+    return [table for table in tables if len(table.columns) > min_cols]
+
+
+def make_text_columns(words: list[TextWord], x_tol: int = 2, min_words: int = 3) -> list[TextColumn]:
+    """Build TextColumns based on x0 alignment of TextWords.
+
+    Args:
+        words: List of TextWords on the page.
+        x_tol: Tolerance for x0 alignment (in px).
+        min_words: Minimum number of words in a column to be considered valid.
+
+    Returns:
+        List of detected TextColumns.
+    """
+    clusters = cluster_text_elements(words, key_fn=lambda w: w.rect.x0, tolerance=x_tol)
+    return [TextColumn(col) for col in clusters if len(col) >= min_words]
+
+
+def make_text_tables(cols: list[TextColumn]) -> list[TextTable]:
+    """Groups TextColumns into TextTables based on alignment.
+
+    Uses a simple BFS approach.
+
+    Args:
+        cols: List of TextColumns to group into tables.
+
+    Returns:
+        List of detected TextTables.
+    """
+    n = len(cols)
+    visited = [False] * n
+    tables: list[TextTable] = []
+
+    for i in range(n):
+        if visited[i]:
+            continue
+        # BFS
+        queue = [i]
+        visited[i] = True
+        table_columns = [cols[i]]
+        while queue:
+            u = queue.pop()
+            for v in range(n):
+                if visited[v] or v == u:
+                    continue
+                if _columns_align(cols[u], cols[v]):
+                    visited[v] = True
+                    queue.append(v)
+                    table_columns.append(cols[v])
+        table = TextTable(table_columns)
+        tables.append(table)
+
+    return tables
+
+
+def _columns_align(
+    col1: TextColumn,
+    col2: TextColumn,
+    min_vert_overlap: float = 0.80,
+    max_horizontal_overlap: float = 0.10,
+    edge_align_tol: float = 6.0,
+) -> bool:
+    """Checks if two text columns align to form a table structure.
+
+    Conditions:
+    - Top or bottom edges roughly aligned  OR sufficient vertical overlap
+    - have no more than a small horizontal overlap
+    Args:
+        col1: First TextColumn.
+        col2: Second TextColumn.
+        min_vert_overlap: Minimum vertical overlap ratio to consider aligned if edges not aligned.
+        max_horizontal_overlap: Maximum horizontal overlap ratio to consider aligned.
+        edge_align_tol: Tolerance in px for top/bottom edge alignment.
+
+    Returns:
+        True if columns align, False otherwise.
+    """
+    rect1, rect2 = col1.rect, col2.rect
+
+    # Check vertical alignment, if not: check if vertical overlap ratio smaller than allowed
+    if abs(rect1.y0 - rect2.y0) > edge_align_tol or abs(rect1.y1 - rect2.y1) > edge_align_tol:
+        y0, y1 = max(rect1.y0, rect2.y0), min(rect1.y1, rect2.y1)
+        v_inter = max(0.0, y1 - y0)
+        v_ratio = v_inter / max(1e-6, min(rect1.height, rect2.height))
+        if v_ratio < min_vert_overlap:
+            return False
+
+    # Check if horizontal overlap ratio smaller than allowed
+    x0, x1 = max(rect1.x0, rect2.x0), min(rect1.x1, rect2.x1)
+    h_inter = max(0.0, x1 - x0)
+    h_ratio = h_inter / max(1e-6, min(rect1.width, rect2.width))
+    return h_ratio <= max_horizontal_overlap

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pymupdf
 
+from src.bounding_box import _x_center
 from src.page_structure import PageContext
 from src.text_objects import TextColumn, TextTable, TextWord, cluster_connected_components
 
@@ -186,11 +187,6 @@ def _median_line_gap(words: list[TextWord]) -> float:
     ys = sorted((w.rect.y0 + w.rect.y1) / 2.0 for w in words)  # baselines
     gaps = [ys[i + 1] - ys[i] for i in range(len(ys) - 1) if ys[i + 1] > ys[i]]
     return max(10.0, float(np.median(gaps))) if gaps else 20.0
-
-
-def _x_center(rect: pymupdf.Rect) -> float:
-    """Finds middle x position of a rectangle."""
-    return 0.5 * (rect.x0 + rect.x1)
 
 
 def _hproj_overlap_ratio(a: pymupdf.Rect, b: pymupdf.Rect) -> float:

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -38,7 +38,7 @@ def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 2) -> li
     return [table for table in tables if len(table.columns) > min_cols]
 
 
-def make_text_columns(words: list[TextWord], x_tol: int = 2, min_words: int = 3) -> list[TextColumn]:
+def make_text_columns(words: list[TextWord], x_tol: float = 2.0, min_words: int = 3) -> list[TextColumn]:
     """Build TextColumns based on x0 alignment of TextWords.
 
     Args:

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -1,5 +1,5 @@
 from src.page_structure import PageContext
-from src.text_objects import TextColumn, TextTable, TextWord, cluster_text_elements
+from src.text_objects import TextColumn, TextTable, TextWord, cluster_connected_components, cluster_text_elements
 
 
 def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float = 0.5) -> bool:
@@ -64,30 +64,8 @@ def make_text_tables(cols: list[TextColumn]) -> list[TextTable]:
     Returns:
         List of detected TextTables.
     """
-    n = len(cols)
-    visited = [False] * n
-    tables: list[TextTable] = []
-
-    for i in range(n):
-        if visited[i]:
-            continue
-        # BFS
-        queue = [i]
-        visited[i] = True
-        table_columns = [cols[i]]
-        while queue:
-            u = queue.pop()
-            for v in range(n):
-                if visited[v] or v == u:
-                    continue
-                if _columns_align(cols[u], cols[v]):
-                    visited[v] = True
-                    queue.append(v)
-                    table_columns.append(cols[v])
-        table = TextTable(table_columns)
-        tables.append(table)
-
-    return tables
+    components = cluster_connected_components(cols, _columns_align)
+    return [TextTable(comp) for comp in components if len(comp) > 1]
 
 
 def _columns_align(

--- a/src/identifiers/table.py
+++ b/src/identifiers/table.py
@@ -19,7 +19,7 @@ def identify_table(ctx: PageContext, min_conf: float = 0.6, min_coverage: float 
     return any(table.text_coverage(ctx.words) > min_coverage for table in good_text_tables)
 
 
-def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 2) -> list[TextTable]:
+def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 3) -> list[TextTable]:
     """Detects and returns text tables with minimum 3 columns on a page based on aligned text columns.
 
     Args:
@@ -35,7 +35,7 @@ def detect_text_table(ctx: PageContext, x_tol: int = 2, min_cols: int = 2) -> li
         return []
 
     tables = make_text_tables(cols)
-    return [table for table in tables if len(table.columns) > min_cols]
+    return [table for table in tables if len(table.columns) >= min_cols]
 
 
 def make_text_columns(words: list[TextWord], x_tol: float = 2.0, min_words: int = 3) -> list[TextColumn]:

--- a/src/identifiers/title_page.py
+++ b/src/identifiers/title_page.py
@@ -4,7 +4,7 @@ from statistics import stdev
 
 from src.keyword_finding import DATE_PATTERNS, PHONE_PATTERNS, find_pattern
 from src.page_structure import PageContext
-from src.text_objects import TextLine
+from src.text_objects import TextLine, cluster_connected_components
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ def has_centered_layout(ctx: PageContext) -> bool:
     Filters out 'centered' clusters that are actually right-aligned based on x0 spread.
     """
     page_width = ctx.page_rect.width
-    centered_clusters = find_aligned_clusters(
+    centered_clusters = cluster_aligned_text_lines(
         ctx.lines, key_func=lambda line: line.rect.x0 + 0.5 * line.rect.width, threshold=0.05 * page_width
     )
 
@@ -157,7 +157,7 @@ def get_all_layout_clusters(lines: list[TextLine], page_width: float) -> list[li
 
     for layout in layout_funcs:
         unassigned_lines = list(remaining_lines)
-        clusters = find_aligned_clusters(unassigned_lines, layout, threshold=0.05 * page_width)
+        clusters = cluster_aligned_text_lines(unassigned_lines, layout, threshold=0.05 * page_width)
 
         for cluster in clusters:
             all_clusters.append(cluster)
@@ -166,54 +166,39 @@ def get_all_layout_clusters(lines: list[TextLine], page_width: float) -> list[li
     return all_clusters
 
 
-def find_aligned_clusters(
-    lines: list[TextLine], key_func: Callable[[TextLine], float], threshold: float
+def cluster_aligned_text_lines(
+    lines: list[TextLine],
+    key_func: Callable[[TextLine], float],
+    threshold: float,
 ) -> list[list[TextLine]]:
-    """Groups text lines into alignment clusters based on a key function (e.g. x0-position).
+    """Cluster text lines that are aligned.
 
-    This function finds clusters of visually aligned lines by comparing each line’s alignment key
-    (e.g. x0, center, x1) and vertical position.
+    A line joins a cluster if:
+      - Its alignment key (e.g., x0, center, x1) differs by less than `threshold`.
+      - Its vertical distance is within a multiple of the font size.
 
-       Parameters:
-        lines (list[TextLine]): List of text lines to cluster.
-        key_func (Callable): Function to extract the alignment key from a line (e.g. lambda l: l.rect.x0).
-        threshold (float): Maximal misalignment between lines for them to be considered aligned.
+    Args:
+        lines: Text lines to cluster.
+        key_func: Function that extracts an alignment key (e.g., lambda l: l.rect.x0).
+        threshold: Max misalignment tolerated for lines to be grouped.
 
     Returns:
-        list[list[TextLine]]: List of clusters, each a list of aligned TextLines.
+        Clusters of aligned lines, each as a list of TextLines.
     """
-    remaining_lines = set(lines)
-    clusters = []
+    if not lines:
+        return []
+    lines = sorted(lines, key=lambda line: line.rect.y0)
 
-    for current_line in sorted(lines, key=lambda line: line.rect.y0):
-        if current_line not in remaining_lines:
-            continue  # already clustered
+    def is_conn(a: TextLine, b: TextLine) -> bool:
+        # misalignment on key
+        if abs(key_func(a) - key_func(b)) >= threshold:
+            return False
+        # vertical closeness
+        vertical_distance = abs(a.rect.y0 - b.rect.y0)
+        limit = VERTICAL_SPACING_FACTOR * max(a.font_size, b.font_size)
+        return vertical_distance < limit
 
-        remaining_lines.remove(current_line)
-        cluster = []
-        line_queue = [current_line]
-
-        while line_queue:
-            line = line_queue.pop()
-            cluster_key = key_func(line)
-            cluster.append(line)
-            font_size = line.font_size
-
-            close_lines = {
-                other
-                for other in remaining_lines
-                if abs(key_func(other) - cluster_key) < threshold  # limit for how much misaligned other line can be
-                and abs(other.rect.y0 - line.rect.y0)
-                < VERTICAL_SPACING_FACTOR * font_size  # limit for how far below other line can lie
-            }
-
-            line_queue.extend(close_lines)  # add close lines into queue
-            remaining_lines -= close_lines  # remove all close lines
-
-        if len(cluster) > 1:
-            clusters.append(cluster)
-
-    return clusters
+    return [c for c in cluster_connected_components(lines, is_conn) if len(c) > 1]
 
 
 def vertical_spacing(lines: list[TextLine]) -> list[float]:

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -5,7 +5,6 @@ From:
 - the swissgeol-boreholes-dataextraction repo (https://github.com/swisstopo/swissgeol-boreholes-dataextraction)
 """
 
-import logging
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -16,8 +15,6 @@ import pymupdf
 from src.bounding_box import merge_bounding_boxes
 
 T = TypeVar("T")
-
-logger = logging.getLogger(__name__)
 
 
 class TextWord:
@@ -171,7 +168,7 @@ def create_text_blocks(text_lines: list[TextLine]) -> list[TextBlock]:
     return blocks
 
 
-def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], tolerance: int = 10.0) -> list[list[T]]:
+def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], tolerance: float = 10.0) -> list[list[T]]:
     """Cluster text elements based on coordinates of bounding box.
 
     Args:

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -5,8 +5,10 @@ From:
 - the swissgeol-boreholes-dataextraction repo (https://github.com/swisstopo/swissgeol-boreholes-dataextraction)
 """
 
+import logging
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import TypeVar
 
 import pymupdf
@@ -14,6 +16,8 @@ import pymupdf
 from src.bounding_box import merge_bounding_boxes
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class TextWord:
@@ -167,7 +171,7 @@ def create_text_blocks(text_lines: list[TextLine]) -> list[TextBlock]:
     return blocks
 
 
-def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], tolerance: int = 10) -> list[list[T]]:
+def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], tolerance: int = 10.0) -> list[list[T]]:
     """Cluster text elements based on coordinates of bounding box.
 
     Args:
@@ -200,3 +204,59 @@ def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], toler
     clusters = list(grouped.values())
 
     return clusters
+
+
+@dataclass
+class TextColumn:
+    """A vertical column of text, composed of multiple TextWords."""
+
+    words: list[TextWord]
+
+    @property
+    def rect(self):
+        return merge_bounding_boxes([w.rect for w in self.words])
+
+
+@dataclass
+class TextTable:
+    """A table composed of multiple aligned TextColumns."""
+
+    columns: list[TextColumn]
+    words: list = field(init=False)
+
+    def __post_init__(self):
+        self.words = [word for col in self.columns for word in col.words]
+
+    @property
+    def rect(self) -> pymupdf.Rect:
+        return merge_bounding_boxes([c.rect for c in self.columns if c.rect is not None])
+
+    def text_coverage(self, all_words: list[TextWord]):
+        """Fraction of words in the table relative to all words on the page."""
+        if not all_words:
+            return 0.0
+        return sum(len(col.words) for col in self.columns) / len(all_words)
+
+    @property
+    def confidence(self):
+        """Confidence based on row alignment across columns.
+
+        Steps:
+        - Collect row centers from all columns.
+        - Merge centers within a tolerance (rows aligning across columns).
+        - Confidence = 1 -  (#merged rows) / (total entries).
+        """
+        if not self.columns:
+            return 0.0
+
+        merged_rows = cluster_text_elements(self.words, key_fn=lambda w: (w.rect.y0 + w.rect.y1) / 2, tolerance=3.0)
+
+        total_entries = len(self.words)
+        if total_entries == 0:
+            return 0.0
+
+        # fewer merged rows relative to total entries -> better alignment
+        merged_count = len(merged_rows)
+        q_rows = 1.0 - (merged_count / total_entries)
+
+        return q_rows

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -26,7 +26,7 @@ class TextWord:
         self.page_number = page
 
     def __repr__(self) -> str:
-        return f"TextWord({self.rect}, {self.text})"
+        return f"TextWord({self.text},{self.rect},)"
 
 
 def extract_words(page, page_number):
@@ -251,6 +251,20 @@ class TextColumn:
     def rect(self):
         return merge_bounding_boxes([w.rect for w in self.words])
 
+    def __repr__(self):
+        return f"TextColumn({[word.text for word in self.words]},{self.rect},)"
+
+    def noise(self, all_words) -> float:
+        """Metric that shows how noisy a column is.
+
+        It's the ratio between actual column entries and non-column words overlapping with the column bounding box.
+        Best noise = 1 (intersecting words = self.words). More intersecting words will lead to a higher ratio.
+        """
+        column_bbox = self.rect
+        intersecting_words = [word for word in all_words if column_bbox.intersects(word.rect)]
+        ratio = len(intersecting_words) / len(self.words)
+        return ratio
+
 
 @dataclass
 class TextTable:
@@ -266,11 +280,12 @@ class TextTable:
     def rect(self) -> pymupdf.Rect:
         return merge_bounding_boxes([c.rect for c in self.columns if c.rect is not None])
 
-    def text_coverage(self, all_words: list[TextWord]):
-        """Fraction of words in the table relative to all words on the page."""
+    def text_coverage(self, all_words: list[TextWord]) -> float:
+        """Fraction of words belonging to the table relative to all words on the page."""
         if not all_words:
             return 0.0
-        return sum(len(col.words) for col in self.columns) / len(all_words)
+        coverage = sum(len(col.words) for col in self.columns) / len(all_words)
+        return coverage
 
     @property
     def confidence(self):

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -257,7 +257,7 @@ class TextTable:
     """A table composed of multiple aligned TextColumns."""
 
     columns: list[TextColumn]
-    words: list = field(init=False)
+    words: list[TextWord] = field(init=False)
 
     def __post_init__(self):
         self.words = [word for col in self.columns for word in col.words]

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -12,7 +12,7 @@ from typing import TypeVar
 
 import pymupdf
 
-from src.bounding_box import merge_bounding_boxes
+from src.bounding_box import _y_center, merge_bounding_boxes
 
 T = TypeVar("T")
 
@@ -299,7 +299,11 @@ class TextTable:
         if not self.columns:
             return 0.0
 
-        merged_rows = cluster_text_elements(self.words, key_fn=lambda w: (w.rect.y0 + w.rect.y1) / 2, tolerance=3.0)
+        def _same_row(w1: TextWord, w2: TextWord, tolerance: float = 3.0):
+            w1_center, w2_center = _y_center(w1.rect), _y_center(w2.rect)
+            return abs(w1_center - w2_center) <= tolerance
+
+        merged_rows = cluster_connected_components(self.words, _same_row)
 
         total_entries = len(self.words)
         if total_entries == 0:

--- a/src/text_objects.py
+++ b/src/text_objects.py
@@ -203,6 +203,44 @@ def cluster_text_elements(elements: list[T], key_fn: Callable[[T], float], toler
     return clusters
 
 
+def cluster_connected_components(items: list[T], is_connected: Callable[[T, T], bool]) -> list[list[T]]:
+    """Generic BFS clustering of items into connected components.
+
+    Each item is connected to others if `is_connected(a, b)` returns True.
+    Items that can be reached transitively form one cluster.
+
+    Args:
+        items: List of objects to cluster.
+        is_connected: Predicate that decides whether two items are connected.
+
+    Returns:
+        List of clusters, where each cluster is a list of connected items.
+    """
+    n = len(items)
+    visited = [False] * n
+    components: list[list[T]] = []
+
+    for i in range(n):
+        if visited[i]:
+            continue
+        # BFS
+        queue = [i]
+        visited[i] = True
+        component = [items[i]]
+        while queue:
+            u = queue.pop()
+            for v in range(n):
+                if visited[v] or v == u:
+                    continue
+                if is_connected(items[u], items[v]):
+                    visited[v] = True
+                    queue.append(v)
+                    component.append(items[v])
+        components.append(component)
+
+    return components
+
+
 @dataclass
 class TextColumn:
     """A vertical column of text, composed of multiple TextWords."""

--- a/tests/test_title_page.py
+++ b/tests/test_title_page.py
@@ -1,6 +1,6 @@
 import pymupdf
 
-from src.identifiers.title_page import VERTICAL_SPACING_FACTOR, find_aligned_clusters
+from src.identifiers.title_page import VERTICAL_SPACING_FACTOR, cluster_aligned_text_lines
 from src.text_objects import TextLine, TextWord
 
 
@@ -15,7 +15,7 @@ def test_x0_cluster():
         TextLine([TextWord(pymupdf.Rect(100, 145, 200, 155), "Line 2", 0)]),
         TextLine([TextWord(pymupdf.Rect(100, 190, 200, 200), "Line 3", 0)]),
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
+    clusters = cluster_aligned_text_lines(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 1
     assert len(clusters[0]) == 3
 
@@ -28,7 +28,7 @@ def test_two_x0_clusters():
         TextLine([TextWord(pymupdf.Rect(300, 100, 400, 110), "Line 1 in cluster 2", 0)]),
         TextLine([TextWord(pymupdf.Rect(298, 130, 400, 140), "Line 2 in cluster 2", 0)]),
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
+    clusters = cluster_aligned_text_lines(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 2
     for cluster in clusters:
         assert len(cluster) == 2
@@ -41,7 +41,7 @@ def test_transitive_inclusion():
         TextLine([TextWord(pymupdf.Rect(104, 130, 204, 140), "Line B", 0)]),  # B
         TextLine([TextWord(pymupdf.Rect(108, 160, 208, 170), "Line C", 0)]),  # C
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
+    clusters = cluster_aligned_text_lines(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 1
     assert len(clusters[0]) == 3
 
@@ -53,7 +53,7 @@ def test_no_clusters_x0():
         TextLine([TextWord(pymupdf.Rect(300, 300, 400, 310), "Line B", 0)]),
         TextLine([TextWord(pymupdf.Rect(500, 500, 600, 510), "Line C", 0)]),
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
+    clusters = cluster_aligned_text_lines(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 0
 
 
@@ -64,5 +64,5 @@ def test_no_cluster_y0():
         TextLine([TextWord(pymupdf.Rect(100, 160, 200, 170), "Line B", 0)]),  # > 5 * height away
         TextLine([TextWord(pymupdf.Rect(100, 210, 200, 220), "Line C", 0)]),  # > 5 * height away
     ]
-    clusters = find_aligned_clusters(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
+    clusters = cluster_aligned_text_lines(lines, key_func=lambda line: line.rect.x0, threshold=VERTICAL_SPACING_FACTOR)
     assert len(clusters) == 0


### PR DESCRIPTION
Roseolves #47 This pull request adds table detection to the baseline classifier using logic solely based on text alignment and structure. 
**Table detection and classification:**

* Added `src/identifiers/table.py` that implements functions to detect tables on a page based on confidence about a detected table (grouped TextColumns).

**extended text object model:**

* Added new dataclasses `TextColumn` and `TextTable` to `src/text_objects.py`, representing vertical columns and tables of text, respectively. These classes have properties for bounding box merging, text coverage, and table confidence (based on row alignment)
* Refactored `cluster_text_elements` to accept a float instead of integers
* Created generic BFS function cluster_connected_components in `src/text_objects.py` which is used both in creation of clusters in title page detection and table detection
**Metrics:**

|Metric | text | boreprofile | map | geo_profile | title_page | diagram | table | unknown | Macro Avg
|-- | -- | -- | -- | -- | -- | -- | -- | -- | --
|F1 Score (%) | 65.00 |75.47 | 74.51 |36.36 |50.00| 0.00 |34.78 | 23.19 | 44.91


