### PR TITLE
refactor/issue-45/api-response-pydantic

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,10 +9,11 @@ ENABLE_COLOR_PROPORTION=false
 AWS_MODEL_ID="your_model_id"
 AWS_MODEL_REGION="anthropic_region"
 
-FASTTEXT_MODEL_PATH = "path_to_FastText_model"
+FASTTEXT_MODEL_PATH="path_to_FastText_model"
 
 S3_BUCKET="asset-sg"
 S3_FOLDER="asset-sg/"
+TMP_PATH="/tmp"
 
 
 # set USE_LOCAL to True and the local configs to use a local S3 instance

--- a/api/api.py
+++ b/api/api.py
@@ -6,14 +6,17 @@ import uuid
 from pathlib import Path
 from typing import Annotated
 
-from aws import aws
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Response, status
-from pydantic import BaseModel, Field
-from starlette.responses import JSONResponse
 
-from utils import task
-from utils.mapping import map_labels_for_app
-from utils.settings import ApiSettings, api_settings
+from api.aws import aws
+from api.utils import task
+from api.utils.schemas import (
+    CollectPayload,
+    CollectResponse,
+    ErrorResponse,
+    StartPayload,
+)
+from api.utils.settings import ApiSettings, api_settings
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from main import main as script
@@ -24,18 +27,19 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
 
 
-class StartPayload(BaseModel):
-    """Payload for starting a new task."""
-
-    file: str = Field(min_length=5)
-
-
-@app.post("/")
+@app.post(
+    "/",
+    status_code=204,
+    responses={
+        400: {"model": ErrorResponse, "description": "Bad request (must be a PDF file)"},
+        422: {"model": ErrorResponse, "description": "File does not exist in S3"},
+    },
+)
 def start(
     payload: StartPayload,
     settings: Annotated[ApiSettings, Depends(api_settings)],
     background_tasks: BackgroundTasks,
-):
+) -> Response:
     if not payload.file.endswith(".pdf"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={"message": "input must be a PDF file"})
 
@@ -53,16 +57,15 @@ def start(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-class CollectPayload(BaseModel):
-    """Payload for collecting task results."""
-
-    file: str = Field(min_length=1)
-
-
-@app.post("/collect")
-def collect(
-    payload: CollectPayload,
-):
+@app.post(
+    "/collect",
+    response_model=CollectResponse,
+    responses={
+        422: {"model": ErrorResponse, "description": "Classification not running for this file"},
+        500: {"model": ErrorResponse, "description": "Internal server error during processing"},
+    },
+)
+def collect(payload: CollectPayload) -> CollectResponse:
     result = task.collect_result(payload.file)
     if result is None and not task.has_task(payload.file):
         raise HTTPException(
@@ -70,34 +73,18 @@ def collect(
             detail={"message": "Page Classification is not running for this file"},
         )
 
-    has_finished = result is not None
-    if not has_finished:
+    if result is None:
         logging.info(f"Processing of '{payload.file}' has not yet finished.")
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={
-                "has_finished": False,
-                "data": None,
-            },
-        )
+        return CollectResponse(has_finished=False, data=None)
 
     if result.ok:
         logging.info(f"Processing of '{payload.file}' has been successful.")
-        return JSONResponse(
-            status_code=status.HTTP_200_OK,
-            content={
-                "has_finished": True,
-                "data": result.value,
-            },
-        )
+        return CollectResponse.create_response(result.value)
 
-    logging.info(f"Processing of '{payload.file}' has failed.")
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content={
-            "has_finished": True,
-            "error": "Internal Server Error",
-        },
+    logging.error(f"Processing of '{payload.file}' has failed.")
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"message": "Internal Server Error during processing"},
     )
 
 
@@ -105,12 +92,26 @@ def process(
     payload: StartPayload,
     aws_client: aws.Client,
     settings: Annotated[ApiSettings, Depends(api_settings)],
-):
+) -> list[dict]:
+    """Process a PDF file from S3 for page classification.
+
+    Downloads the file from S3, runs the classification model, and returns the predictions.
+    Creates a temporary directory for processing and cleans it up afterward.
+
+    Args:
+        payload: The payload containing the PDF file name to download and process
+        aws_client: AWS client instance for S3 operations
+        settings: API settings including S3 bucket, folder, and temp path configurations
+
+    Returns:
+        list[dict]: List of raw predictions from the classification pipeline. Note that these are raw pipeline outputs,
+        class labels will be translated to their final form during response object construction.
+    """
     task_id = f"{uuid.uuid4()}"
     tmp_dir = Path(settings.tmp_path) / task_id
     os.makedirs(tmp_dir, exist_ok=True)
 
-    input_path = tmp_dir / "input.pdf"
+    input_path = tmp_dir / payload.file
 
     aws.load_file(
         aws_client.bucket(settings.s3_bucket),
@@ -124,6 +125,5 @@ def process(
         model_path="models/stable/model.joblib",
         write_result=False,
     )
-    result = [map_labels_for_app(doc) for doc in result]
     shutil.rmtree(tmp_dir)
     return result

--- a/api/aws/aws.py
+++ b/api/aws/aws.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 from mypy_boto3_s3 import S3ServiceResource
 from mypy_boto3_s3.service_resource import Bucket
 
-from utils.settings import ApiSettings
+from api.utils.settings import ApiSettings
 
 
 @dataclass

--- a/api/utils/mapping.py
+++ b/api/utils/mapping.py
@@ -2,17 +2,15 @@
 APP_LABELS: dict[str, str] = {
     "text": "Text",
     "boreprofile": "Boreprofile",
-    "map": "Maps",
-    "title_page": "Title_Page",
+    "map": "Map",
+    "title_page": "TitlePage",
+    "geo_profile": "GeoProfile",
+    "table": "Table",
+    "diagram": "Diagram",
     "unknown": "Unknown",
 }
 
 
-def map_labels_for_app(doc: dict) -> dict:
-    """Return a copy of the classification results with classification keys renamed to the app’s labels."""
-    pages = []
-    for p in doc.get("pages", []):
-        cls = p.get("classification", {}) or {}
-        cls = {APP_LABELS.get(key, key): value for key, value in cls.items()}  # rename only
-        pages.append({**p, "classification": cls})
-    return {**doc, "pages": pages}
+def parse_predicted_class(classification: dict) -> str:
+    """Parse the predicted class from a one-hot encoded classification dictionary."""
+    return next((APP_LABELS.get(k, k) for k, v in classification.items() if v == 1), "Unknown")

--- a/api/utils/schemas.py
+++ b/api/utils/schemas.py
@@ -70,7 +70,7 @@ class PagePrediction(BaseModel):
 
     predicted_class: str
     page_number: int = Field(gt=0, description="Page number must be greater than 0")
-    page_meta_data: PageMetaDataSchema
+    page_metadata: PageMetaDataSchema
 
     @classmethod
     def from_prediction(cls, prediction: dict):

--- a/api/utils/schemas.py
+++ b/api/utils/schemas.py
@@ -1,0 +1,130 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.utils.mapping import parse_predicted_class
+
+
+class ErrorResponse(BaseModel):
+    """Error response model."""
+
+    detail: str
+
+
+class StartPayload(BaseModel):
+    """Payload model for initiating a new document processing task."""
+
+    file: str = Field(min_length=5)
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,  # This allows using non-standard types like Path
+        json_schema_extra={
+            "example": {"file": "10122_1.pdf"},
+        },
+    )
+
+
+class StartResponse(BaseModel):
+    """Response returned when a task has been successfully started."""
+
+    message: str
+
+
+class CollectPayload(BaseModel):
+    """Payload model for retrieving results of a processed document."""
+
+    file: str = Field(min_length=1)
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,  # This allows using non-standard types like Path
+        json_schema_extra={
+            "example": {"file": "10122_1.pdf"},
+        },
+    )
+
+
+class MetaDataSchema(BaseModel):
+    """Schema for document-level metadata including page count and languages."""
+
+    page_count: int
+    languages: list[str]
+
+    @classmethod
+    def from_prediction(cls, metadata: dict):
+        if not all(key in metadata for key in ["page_count", "languages"]):
+            raise ValueError("Missing required metadata fields: page_count, languages")
+        return cls(page_count=metadata["page_count"], languages=metadata["languages"])
+
+
+class PageMetaDataSchema(BaseModel):
+    """Schema for page-level metadata including language and frontpage status."""
+
+    language: str | None
+    is_frontpage: bool
+
+    @classmethod
+    def from_prediction(cls, metadata: dict):
+        return cls(language=metadata["language"], is_frontpage=metadata["is_frontpage"])
+
+
+class PagePrediction(BaseModel):
+    """Schema for individual page prediction results including class, number and metadata."""
+
+    predicted_class: str
+    page_number: int = Field(gt=0, description="Page number must be greater than 0")
+    page_meta_data: PageMetaDataSchema
+
+    @classmethod
+    def from_prediction(cls, prediction: dict):
+        return cls(
+            predicted_class=parse_predicted_class(prediction["classification"]),
+            page_number=prediction["page"],
+            page_meta_data=PageMetaDataSchema.from_prediction(prediction["metadata"]),
+        )
+
+
+class PredictionSchema(BaseModel):
+    """Schema for the complete document prediction results including metadata and page predictions."""
+
+    filename: str
+    metadata: MetaDataSchema
+    pages: list[PagePrediction]
+
+    @classmethod
+    def from_prediction(cls, prediction: dict[dict]):
+        return cls(
+            filename=prediction["filename"],
+            metadata=MetaDataSchema.from_prediction(prediction["metadata"]),
+            pages=[PagePrediction.from_prediction(page_pred) for page_pred in prediction["pages"]],
+        )
+
+
+class CollectResponse(BaseModel):
+    """Response model for the collect request endpoint containing processing status and results."""
+
+    has_finished: bool
+    data: list[PredictionSchema] | None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "has_finished": True,
+                "data": [
+                    {
+                        "filename": "input.pdf",
+                        "metadata": {"page_count": 1, "languages": ["fr"]},
+                        "pages": [
+                            {
+                                "predicted_class": "Map",
+                                "page_number": 1,
+                                "page_meta_data": {"language": "fr", "is_frontpage": True},
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+
+    @classmethod
+    def create_response(cls, predictions: list[dict]):
+        """Currently the api only handles requests with one file, `predictions` is a list of only one element."""
+        return cls(has_finished=True, data=[PredictionSchema.from_prediction(pred) for pred in predictions])

--- a/tests/test_api_mapping.py
+++ b/tests/test_api_mapping.py
@@ -1,26 +1,17 @@
-from api.utils.mapping import APP_LABELS, map_labels_for_app
+import pytest
+
+from api.utils.mapping import parse_predicted_class
 
 
-def make_doc(cls=None):
-    return {
-        "filename": "sample.pdf",
-        "metadata": {"page_count": 1, "languages": ["de"]},
-        "pages": [
-            {
-                "page": 1,
-                "classification": cls or {"text": 1, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0},
-                "metadata": {"language": "de", "is_frontpage": False},
-            }
-        ],
-    }
-
-
-def test_mapping_to_stable_labels():
-    doc = make_doc(cls={"text": 0, "boreprofile": 1, "map": 0, "title_page": 0, "unknown": 0})
-    out = map_labels_for_app(doc)
-    page = out["pages"][0]
-    # all app labels present and renamed
-    assert set(page["classification"].keys()) == set(APP_LABELS.values())
-    # value preserved on the renamed key
-    assert page["classification"][APP_LABELS["boreprofile"]] == 1
-    assert sum(page["classification"].values()) == 1
+@pytest.mark.parametrize(
+    "classes,expected",
+    [
+        ({"text": 0, "boreprofile": 1, "map": 0, "title_page": 0, "unknown": 0}, "Boreprofile"),
+        ({"text": 0, "boreprofile": 0, "map": 1, "title_page": 0, "unknown": 0}, "Map"),
+        ({"text": 0, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, "Unknown"),
+        ({"TEXTTT": 1, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, "TEXTTT"),
+    ],
+)
+def test_mapping_to_stable_labels(classes, expected):
+    page_pred = parse_predicted_class(classes)
+    assert page_pred == expected


### PR DESCRIPTION
The `/collect` endpoint now returns a CollectResponse object instead of a JSONResponse. If processing fails, it raises a 500 error rather than returning a 200 status code.

CollectResponse follows essentially the same structure as the previous JSON dictionary:
```
{
    "has_finished": True,
    "data": [
        {
            "filename": "input.pdf",
            "metadata": {
                "page_count": 1,
                "languages": [
                    "fr"
                ]
            },
            "pages": [
                {
                    "predicted_class": "Map",
                    "page_number": 1,
                    "page_metadata": {
                        "language": "fr",
                        "is_frontpage": True
                    },
                }
            ],
        }
    ],
}
```
Compared to earlier responses, some fields have been renamed for clarity (e.g., page → page_number). Additionally, classification has been replaced by predicted_class, which now contains a simple string with the predicted value instead of a one-hot encoded dictionary of all classes. This change could be reverted if needed.

Previous schema for reference:
```
{
    "has_finished": False,
    "data": [
        {
            "filename": "sample.pdf",
            "metadata": {
                "page_count": 1,
                "languages": [
                    "de"
                ]
            },
            "pages": [
                {
                    "page": 1,
                    "classification": {
                        "text": 1,
                        "boreprofile": 0,
                        "map": 0,
                        "title_page": 0,
                        "unknown": 0
                    },
                    "metadata": {
                        "language": "de",
                        "is_frontpage": False
                    },
                }
            ],
        },
    ]
}
```
The class mapping has been updated to follow a consistent format.