### PR TITLE
type hint enum to see from the api

### DIFF
--- a/api/app/v1/schemas.py
+++ b/api/app/v1/schemas.py
@@ -1,6 +1,18 @@
+from enum import Enum
+from typing import TypeAlias
+
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_pascal
 
 from src.page_classes import PageClasses
+
+# dynamically created Enum to expose PascalCase class names to the API.
+PascalPageClasses = Enum(
+    "PascalPageClasses",
+    {name: to_pascal(value) for name, value in PageClasses.__members__.items()},
+    type=str,
+)
+PascalPageClasses: TypeAlias = PascalPageClasses  # pyright: ignore[reportInvalidTypeForm]
 
 
 class MetaDataSchema(BaseModel):
@@ -30,7 +42,7 @@ class PageMetaDataSchema(BaseModel):
 class PagePrediction(BaseModel):
     """Schema for individual page prediction results including class, number and metadata."""
 
-    predicted_class: PageClasses
+    predicted_class: PascalPageClasses
     page_number: int = Field(gt=0, description="Page number must be greater than 0")
     page_metadata: PageMetaDataSchema
 
@@ -98,13 +110,13 @@ class ErrorResponse(BaseModel):
     detail: str
 
 
-def predicted_class(classification: dict[str:int]) -> PageClasses:
+def predicted_class(classification: dict[str:int]) -> PascalPageClasses:
     """Parse the predicted class from a one-hot encoded classification dictionary.
 
     The values of the dict are the sting representation of each class in the PageClasses enum.
     """
-    value = next((k for k, v in classification.items() if v == 1), PageClasses.UNKNOWN.value)
+    value = next((k for k, v in classification.items() if v == 1), "unknown")
     try:
-        return PageClasses(value)
+        return PascalPageClasses(to_pascal(value))
     except ValueError:
-        return PageClasses.UNKNOWN
+        return PascalPageClasses.UNKNOWN

--- a/api/app/v1/schemas.py
+++ b/api/app/v1/schemas.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.alias_generators import to_pascal
 
 from src.page_classes import PageClasses
 
@@ -99,10 +98,13 @@ class ErrorResponse(BaseModel):
     detail: str
 
 
-def predicted_class(classification: dict) -> PageClasses:
-    """Parse the predicted class from a one-hot encoded classification dictionary."""
-    value = next((to_pascal(k) for k, v in classification.items() if v == 1), "Unknown")
+def predicted_class(classification: dict[str:int]) -> PageClasses:
+    """Parse the predicted class from a one-hot encoded classification dictionary.
+
+    The values of the dict are the sting representation of each class in the PageClasses enum.
+    """
+    value = next((k for k, v in classification.items() if v == 1), PageClasses.UNKNOWN.value)
     try:
-        return PageClasses(value.lower())  # match your enum values
+        return PageClasses(value)
     except ValueError:
         return PageClasses.UNKNOWN

--- a/api/app/v1/schemas.py
+++ b/api/app/v1/schemas.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_pascal
 
+from src.page_classes import PageClasses
+
 
 class MetaDataSchema(BaseModel):
     """Schema for document-level metadata including page count and languages."""
@@ -29,7 +31,7 @@ class PageMetaDataSchema(BaseModel):
 class PagePrediction(BaseModel):
     """Schema for individual page prediction results including class, number and metadata."""
 
-    predicted_class: str
+    predicted_class: PageClasses
     page_number: int = Field(gt=0, description="Page number must be greater than 0")
     page_metadata: PageMetaDataSchema
 
@@ -97,6 +99,10 @@ class ErrorResponse(BaseModel):
     detail: str
 
 
-def predicted_class(classification: dict) -> str:
+def predicted_class(classification: dict) -> PageClasses:
     """Parse the predicted class from a one-hot encoded classification dictionary."""
-    return next((to_pascal(k) for k, v in classification.items() if v == 1), "Unknown")
+    value = next((to_pascal(k) for k, v in classification.items() if v == 1), "Unknown")
+    try:
+        return PageClasses(value.lower())  # match your enum values
+    except ValueError:
+        return PageClasses.UNKNOWN

--- a/src/page_classes.py
+++ b/src/page_classes.py
@@ -3,7 +3,7 @@
 from enum import Enum
 
 
-class PageClasses(Enum):
+class PageClasses(str, Enum):
     """Enum for classifying pages into page types."""
 
     TEXT = "text"

--- a/tests/test_api_mapping.py
+++ b/tests/test_api_mapping.py
@@ -1,17 +1,18 @@
 import pytest
 
-from api.utils.mapping import parse_predicted_class
+from api.app.v1.schemas import predicted_class
+from src.page_classes import PageClasses
 
 
 @pytest.mark.parametrize(
     "classes,expected",
     [
-        ({"text": 0, "boreprofile": 1, "map": 0, "title_page": 0, "unknown": 0}, "Boreprofile"),
-        ({"text": 0, "boreprofile": 0, "map": 1, "title_page": 0, "unknown": 0}, "Map"),
-        ({"text": 0, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, "Unknown"),
-        ({"TEXTTT": 1, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, "TEXTTT"),
+        ({"text": 0, "boreprofile": 1, "map": 0, "title_page": 0, "unknown": 0}, PageClasses.BOREPROFILE),
+        ({"text": 0, "boreprofile": 0, "map": 1, "title_page": 0, "unknown": 0}, PageClasses.MAP),
+        ({"text": 0, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, PageClasses.UNKNOWN),
+        ({"TEXTTT": 1, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, PageClasses.UNKNOWN),
     ],
 )
 def test_mapping_to_stable_labels(classes, expected):
-    page_pred = parse_predicted_class(classes)
+    page_pred = predicted_class(classes)
     assert page_pred == expected


### PR DESCRIPTION
Resolves #72 

This PR updates the PageClasses enum to inherit from str and implements a dynamically created Enum with PascalCase values for the classes. This Enum is then exposed in the API making the enum values visible in the FastAPI documentation at /v1/docs.

Here is the nested structure showing the CollectResponse object.
<img width="622" height="698" alt="image" src="https://github.com/user-attachments/assets/634a0ba5-d18e-4e91-a3cc-73539a7ebf61" />

