### PR TITLE
Return document structure API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,6 @@ The V1 version containes extended classes from v0 and Each page is categorized i
 
 
 #### Example Output (v2)
-# TODO: Add test functions
-# TODO: Check that files are deleted after usage
-# TODO: Check aggregation with large document 35016
 
 ```json
 {
@@ -173,13 +170,6 @@ The V1 version containes extended classes from v0 and Each page is categorized i
 	],
 }
 ```
-**V1 Notes**:
-- `filename`: The name of the processed PDF file.
-- `metadata`: metadata about the file.
-- `pages`: list of dictionaries containing:
-  - `predicted_class`: The class name of the predicted class (e.g. "Boreprofile"). All possible classes are listed above in the section "Classes".
-  - `page_number`: The page number (1-indexed).
-  - `page_metadata`: metadata about the current page.
 
 
 #### General Notes

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The V1 version containes extended classes from v0 and Each page is categorized i
 
 
 ## Output Format
-`data/prediction.json` (if `-w`/`--write_result`) or returned as a Python object.
+
 #### Example Output (v0)
 ```json
 {
@@ -146,7 +146,43 @@ The V1 version containes extended classes from v0 and Each page is categorized i
   - `page_metadata`: metadata about the current page.
 
 
-**General Notes:**
+#### Example Output (v2)
+# TODO: Add test functions
+# TODO: Check that files are deleted after usage
+# TODO: Check aggregation with large document 35016
+
+```json
+{
+	"has_finished": true,
+	"data": [
+		{
+			"filename": "input.pdf",					// Name of the file
+			"page_count": 3,							// Number of pages
+			"languages": [								// Detected languages
+				"de"
+			],
+			"entities": [								// List of elements present in file
+				{
+					"classification": "boreprofile",	// Type of element (PageClasses)
+					"page_start": 1,					// Starting page
+					"page_end": 3,						// Ending page
+					"language": "de",			    	// Detected language
+				},
+			],
+		}
+	],
+}
+```
+**V1 Notes**:
+- `filename`: The name of the processed PDF file.
+- `metadata`: metadata about the file.
+- `pages`: list of dictionaries containing:
+  - `predicted_class`: The class name of the predicted class (e.g. "Boreprofile"). All possible classes are listed above in the section "Classes".
+  - `page_number`: The page number (1-indexed).
+  - `page_metadata`: metadata about the current page.
+
+
+#### General Notes
 
 - The classifier supports batch input of multiple reports.
 - Input must be preprocessed: PDFs should already have OCR.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The V1 version containes extended classes from v0 and Each page is categorized i
 
 #### Example Output (v2)
 
-```json
+```jsonc
 {
 	"has_finished": true,
 	"data":{

--- a/README.md
+++ b/README.md
@@ -151,23 +151,21 @@ The V1 version containes extended classes from v0 and Each page is categorized i
 ```json
 {
 	"has_finished": true,
-	"data": [
-		{
-			"filename": "input.pdf",					// Name of the file
-			"page_count": 3,							// Number of pages
-			"languages": [								// Detected languages
-				"de"
-			],
-			"entities": [								// List of elements present in file
-				{
-					"classification": "boreprofile",	// Type of element (PageClasses)
-					"page_start": 1,					// Starting page
-					"page_end": 3,						// Ending page
-					"language": "de",			    	// Detected language
-				},
-			],
-		}
-	],
+	"data":{
+		"filename": "input.pdf",					// Name of the file
+		"page_count": 3,							// Number of pages
+		"languages": [								// Detected languages
+			"de"
+		],
+		"entities": [								// List of elements present in file
+			{
+				"classification": "boreprofile",	// Type of element (PageClasses)
+				"page_start": 1,					// Starting page
+				"page_end": 3,						// Ending page
+				"language": "de"			    	// Detected language
+			}
+		]
+	}
 }
 ```
 

--- a/api/api.py
+++ b/api/api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from api.app.v0.router import router as v0
 from api.app.v1.app import app as v1
+from api.app.v2.app import app as v2
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -15,6 +16,7 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)
 
 app.mount("/v1", v1)
+app.mount("/v2", v2)
 
 # note: for backward compatibility, v0 is mounted at the root, and this is only possible via include_router, not mount
 app.include_router(v0)

--- a/api/app/shared/schemas.py
+++ b/api/app/shared/schemas.py
@@ -3,6 +3,12 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class ErrorResponse(BaseModel):
+    """Error response model."""
+
+    detail: str
+
+
 class StartPayload(BaseModel):
     """Payload model for initiating a new document processing task."""
 

--- a/api/app/v0/router.py
+++ b/api/app/v0/router.py
@@ -104,11 +104,12 @@ def process(
         str(input_path),
     )
 
-    documents, _ = script(
+    documents = script(
         input_path=tmp_dir,
         classifier_name="treebased",
         model_path="models/stable/model.joblib",
         write_result=False,
+        return_entities=False,
     )
 
     result = [map_labels_for_v0(doc.model_dump(context={"legacy": True})) for doc in documents]

--- a/api/app/v0/router.py
+++ b/api/app/v0/router.py
@@ -104,13 +104,13 @@ def process(
         str(input_path),
     )
 
-    result = script(
+    documents, _ = script(
         input_path=tmp_dir,
         classifier_name="treebased",
         model_path="models/stable/model.joblib",
         write_result=False,
     )
 
-    result = [map_labels_for_v0(doc) for doc in result]
+    result = [map_labels_for_v0(doc.model_dump(context={"legacy": True})) for doc in documents]
     shutil.rmtree(tmp_dir)
     return result

--- a/api/app/v1/app.py
+++ b/api/app/v1/app.py
@@ -103,11 +103,12 @@ def process(
         str(input_path),
     )
 
-    documents, _ = script(
+    documents = script(
         input_path=tmp_dir,
         classifier_name="treebased",
         model_path="models/stable/model.joblib",
         write_result=False,
+        return_entities=False,
     )
     shutil.rmtree(tmp_dir)
     return [doc.model_dump() for doc in documents]

--- a/api/app/v1/app.py
+++ b/api/app/v1/app.py
@@ -106,11 +106,11 @@ def process(
         str(input_path),
     )
 
-    result = script(
+    documents, _ = script(
         input_path=tmp_dir,
         classifier_name="treebased",
         model_path="models/stable/model.joblib",
         write_result=False,
     )
     shutil.rmtree(tmp_dir)
-    return result
+    return [doc.model_dump() for doc in documents]

--- a/api/app/v1/schemas.py
+++ b/api/app/v1/schemas.py
@@ -104,12 +104,6 @@ class CollectResponse(BaseModel):
         return cls(has_finished=True, data=[PredictionSchema.from_prediction(pred) for pred in predictions])
 
 
-class ErrorResponse(BaseModel):
-    """Error response model."""
-
-    detail: str
-
-
 def predicted_class(classification: PageClasses) -> PascalPageClasses:
     """Parse the predicted class from a one-hot encoded classification dictionary.
 

--- a/api/app/v1/schemas.py
+++ b/api/app/v1/schemas.py
@@ -110,13 +110,12 @@ class ErrorResponse(BaseModel):
     detail: str
 
 
-def predicted_class(classification: dict[str:int]) -> PascalPageClasses:
+def predicted_class(classification: PageClasses) -> PascalPageClasses:
     """Parse the predicted class from a one-hot encoded classification dictionary.
 
     The values of the dict are the sting representation of each class in the PageClasses enum.
     """
-    value = next((k for k, v in classification.items() if v == 1), "unknown")
     try:
-        return PascalPageClasses(to_pascal(value))
+        return PascalPageClasses(to_pascal(classification))
     except ValueError:
         return PascalPageClasses.UNKNOWN

--- a/api/app/v2/__init__.py
+++ b/api/app/v2/__init__.py
@@ -1,0 +1,1 @@
+"""API Module for the v2 endpoints of the Assets application."""

--- a/api/app/v2/app.py
+++ b/api/app/v2/app.py
@@ -1,9 +1,6 @@
 import logging
 import os
-import shutil
 import tempfile
-import uuid
-from pathlib import Path
 from typing import Annotated
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Response, status

--- a/api/app/v2/app.py
+++ b/api/app/v2/app.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import tempfile
 import uuid
 from pathlib import Path
 from typing import Annotated
@@ -10,7 +11,7 @@ from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Response, 
 from api.app.shared.handlers import start_handler
 from api.app.shared.schemas import CollectPayload, ErrorResponse, StartPayload
 from api.app.shared.settings import ApiSettings, api_settings
-from api.app.v1.schemas import CollectResponse
+from api.app.v2.schemas import CollectResponse
 from api.aws import aws
 from api.utils import task
 from main import main as script
@@ -40,7 +41,7 @@ def start(
     "/collect",
     summary="Collect Page Classification Results",
     description="""
-        Collects the results of the Page Classification process for a given file. If the process is still running, 
+        Collects the results of the Page Classification process for a given file. If the process is still running,
         it indicates that the results are not yet available.
     """,
     response_model=CollectResponse,
@@ -91,23 +92,24 @@ def process(
         list[dict]: List of raw predictions from the classification pipeline. Note that these are raw pipeline outputs,
         class labels will be translated to their final form during response object construction.
     """
-    task_id = f"{uuid.uuid4()}"
-    tmp_dir = Path(settings.tmp_path) / task_id
-    os.makedirs(tmp_dir, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a file in the temp folder
+        input_path = os.path.join(temp_dir, payload.file)
 
-    input_path = tmp_dir / payload.file
+        # Laod file locally to be processed
+        aws.load_file(
+            aws_client.bucket(settings.s3_bucket),
+            f"{settings.s3_folder}{payload.file}",
+            input_path,
+        )
 
-    aws.load_file(
-        aws_client.bucket(settings.s3_bucket),
-        f"{settings.s3_folder}{payload.file}",
-        str(input_path),
-    )
+        # Process file in local directory
+        _, entities = script(
+            input_path=temp_dir,
+            classifier_name="treebased",
+            model_path="models/stable/model.joblib",
+            write_result=False,
+        )
 
-    documents, _ = script(
-        input_path=tmp_dir,
-        classifier_name="treebased",
-        model_path="models/stable/model.joblib",
-        write_result=False,
-    )
-    shutil.rmtree(tmp_dir)
-    return [doc.model_dump() for doc in documents]
+    # Return parsed entities
+    return [entity.model_dump() for entity in entities]

--- a/api/app/v2/app.py
+++ b/api/app/v2/app.py
@@ -61,7 +61,7 @@ def collect(payload: CollectPayload) -> CollectResponse:
 
     if result.ok:
         logging.info(f"Processing of '{payload.file}' has been successful.")
-        return CollectResponse.create_response(result.value)
+        return CollectResponse.create_response(result.value[0])
 
     logging.error(f"Processing of '{payload.file}' has failed.")
     raise HTTPException(

--- a/api/app/v2/app.py
+++ b/api/app/v2/app.py
@@ -101,11 +101,12 @@ def process(
         )
 
         # Process file in local directory
-        _, entities = script(
+        entities = script(
             input_path=temp_dir,
             classifier_name="treebased",
             model_path="models/stable/model.joblib",
             write_result=False,
+            return_entities=True,
         )
 
     # Return parsed entities

--- a/api/app/v2/app.py
+++ b/api/app/v2/app.py
@@ -20,7 +20,7 @@ app = FastAPI()
     "/",
     status_code=204,
     summary="Start Page Classification",
-    description="Starts the Page Classification process for a file as background task that completes asynchronously.",
+    description="Starts the page classification process for a file as an asynchronous background task.",
     responses={
         400: {"model": ErrorResponse, "description": "Bad request (must be a PDF file)"},
         422: {"model": ErrorResponse, "description": "File does not exist in S3"},
@@ -52,7 +52,7 @@ def collect(payload: CollectPayload) -> CollectResponse:
     if result is None and not task.has_task(payload.file):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"message": "Page Classification is not running for this file"},
+            detail={"message": "Page classification is not running for this file"},
         )
 
     if result is None:
@@ -60,7 +60,7 @@ def collect(payload: CollectPayload) -> CollectResponse:
         return CollectResponse(has_finished=False, data=None)
 
     if result.ok:
-        logging.info(f"Processing of '{payload.file}' has been successful.")
+        logging.info(f"Processing of '{payload.file}'was successful.")
         return CollectResponse.create_response(result.value[0])
 
     logging.error(f"Processing of '{payload.file}' has failed.")
@@ -86,14 +86,14 @@ def process(
         settings: API settings including S3 bucket, folder, and temp path configurations
 
     Returns:
-        list[dict]: List of raw predictions from the classification pipeline. Note that these are raw pipeline outputs,
-        class labels will be translated to their final form during response object construction.
+        list[dict]: List of raw predictions from the classification pipeline. Note that these are raw pipeline outputs.
+            Class labels will be translated to their final form during response object construction.
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a file in the temp folder
         input_path = os.path.join(temp_dir, payload.file)
 
-        # Laod file locally to be processed
+        # Load file locally to be processed
         aws.load_file(
             aws_client.bucket(settings.s3_bucket),
             f"{settings.s3_folder}{payload.file}",

--- a/api/app/v2/schemas.py
+++ b/api/app/v2/schemas.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel, ConfigDict
+
+from src.page_structure import ProcessorDocumentEntities
+
+
+class CollectResponse(BaseModel):
+    """Response model for the collect request endpoint containing processing status and results."""
+
+    has_finished: bool
+    data: list[ProcessorDocumentEntities] | None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "has_finished": True,
+                "data": [
+                    {
+                        "filename": "input.pdf",
+                        "metadata": {"page_count": 3, "languages": ["de"]},
+                        "entities": [
+                            {
+                                "start_page": 1,
+                                "end_page": 3,
+                                "lang": "de",
+                                "classification": "boreprofile",
+                                "data": None,
+                            },
+                        ],
+                    }
+                ],
+            }
+        }
+    )
+
+    @classmethod
+    def create_response(cls, predictions: list[dict]):
+        """Currently the api only handles requests with one file, `predictions` is a list of only one element."""
+        return cls(has_finished=True, data=[ProcessorDocumentEntities.model_validate(pred) for pred in predictions])

--- a/api/app/v2/schemas.py
+++ b/api/app/v2/schemas.py
@@ -19,10 +19,12 @@ class CollectResponse(BaseModel):
                         "metadata": {"page_count": 3, "languages": ["de"]},
                         "entities": [
                             {
-                                "start_page": 1,
-                                "end_page": 3,
-                                "lang": "de",
                                 "classification": "boreprofile",
+                                "metadata": {
+                                    "page_start": 1,
+                                    "page_end": 3,
+                                    "language": "de",
+                                },
                                 "data": None,
                             },
                         ],

--- a/api/app/v2/schemas.py
+++ b/api/app/v2/schemas.py
@@ -7,32 +7,30 @@ class CollectResponse(BaseModel):
     """Response model for the collect request endpoint containing processing status and results."""
 
     has_finished: bool
-    data: list[ProcessorDocumentEntities] | None
+    data: ProcessorDocumentEntities | None
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
                 "has_finished": True,
-                "data": [
-                    {
-                        "filename": "input.pdf",
-                        "page_count": 3,
-                        "languages": ["de"],
-                        "entities": [
-                            {
-                                "classification": "boreprofile",
-                                "page_start": 1,
-                                "page_end": 3,
-                                "language": "de",
-                            },
-                        ],
-                    }
-                ],
+                "data": {
+                    "filename": "input.pdf",
+                    "page_count": 3,
+                    "languages": ["de"],
+                    "entities": [
+                        {
+                            "classification": "boreprofile",
+                            "page_start": 1,
+                            "page_end": 3,
+                            "language": "de",
+                        },
+                    ],
+                },
             }
         }
     )
 
     @classmethod
-    def create_response(cls, predictions: list[dict]):
-        """Currently the api only handles requests with one file, `predictions` is a list of only one element."""
-        return cls(has_finished=True, data=[ProcessorDocumentEntities.model_validate(pred) for pred in predictions])
+    def create_response(cls, prediction: dict):
+        """Creates response from prediction."""
+        return cls(has_finished=True, data=ProcessorDocumentEntities.model_validate(prediction))

--- a/api/app/v2/schemas.py
+++ b/api/app/v2/schemas.py
@@ -32,5 +32,5 @@ class CollectResponse(BaseModel):
 
     @classmethod
     def create_response(cls, prediction: dict):
-        """Creates response from prediction."""
+        """Creates response from a prediction."""
         return cls(has_finished=True, data=ProcessorDocumentEntities.model_validate(prediction))

--- a/api/app/v2/schemas.py
+++ b/api/app/v2/schemas.py
@@ -16,16 +16,14 @@ class CollectResponse(BaseModel):
                 "data": [
                     {
                         "filename": "input.pdf",
-                        "metadata": {"page_count": 3, "languages": ["de"]},
+                        "page_count": 3,
+                        "languages": ["de"],
                         "entities": [
                             {
                                 "classification": "boreprofile",
-                                "metadata": {
-                                    "page_start": 1,
-                                    "page_end": 3,
-                                    "language": "de",
-                                },
-                                "data": None,
+                                "page_start": 1,
+                                "page_end": 3,
+                                "language": "de",
                             },
                         ],
                     }

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ def forward_document(
 def forward_document_entities(
     documents: list[ProcessorDocument],
 ) -> list[ProcessorDocumentEntities]:
-    """Convert classified docuemnts pages to entities.
+    """Convert classified documents pages to entities.
 
     Args:
         documents (list[ProcessorDocument]): List of documents to process.
@@ -126,6 +126,7 @@ def forward_document_entities(
         # Iterate over grouped entities types
         for (pages_type, lang), pages in document.group_pages_by_type():
             # Get pages sequences
+            pages_id = sorted([page.page for page in pages])
             results_entities.extend(
                 [
                     ProcessedEntities(
@@ -135,7 +136,7 @@ def forward_document_entities(
                         language=lang,
                     )
                     # Group consecutive [1,2,10] -> [1,2], [10]
-                    for pages_group in group_consecutive([page.page for page in pages])
+                    for pages_group in group_consecutive(pages_id)
                 ]
             )
         # Create document from filename, metadata, entities
@@ -235,7 +236,7 @@ def main(
         explain_model=explain_model,
     )
 
-    # Check if data need to be saves
+    # Check if data need to be saved
     if write_result:
         output_file = Path("data") / "prediction.json"
         output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 from src.classifiers.classifier_factory import ClassifierTypes, create_classifier
 from src.page_structure import (
     ProcessedEntities,
-    ProcessedEntitiesMetadata,
     ProcessorDocument,
     ProcessorDocumentEntities,
 )
@@ -130,11 +129,10 @@ def forward_document_entities(
             results_entities.extend(
                 [
                     ProcessedEntities(
-                        metadata=ProcessedEntitiesMetadata(
-                            page_start=min(pages_group), page_end=max(pages_group), language=lang
-                        ),
                         classification=pages_type,
-                        data=None,
+                        page_start=min(pages_group),
+                        page_end=max(pages_group),
+                        language=lang,
                     )
                     # Group consecutive [1,2,10] -> [1,2], [10]
                     for pages_group in group_consecutive([page.page for page in pages])
@@ -143,9 +141,13 @@ def forward_document_entities(
         # Create document from filename, metadata, entities
         documents_entities.append(
             ProcessorDocumentEntities(
-                filename=document.filename, metadata=document.metadata, entities=results_entities
+                filename=document.filename,
+                page_count=document.metadata.page_count,
+                languages=document.metadata.languages,
+                entities=results_entities,
             )
         )
+
     return documents_entities
 
 

--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import argparse
 import json
 import logging
 import os
+from itertools import groupby
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 from src.classifiers.classifier_factory import ClassifierTypes, create_classifier
+from src.page_structure import ProcessedEntities
 from src.pdf_processor import PDFProcessor
 from src.utils import get_pdf_files, read_params
 
@@ -61,6 +63,24 @@ def flatten_dict(d, parent_key="", sep=".") -> dict:
     return dict(items)
 
 
+def group_consecutive(values: list[int]) -> list[list[int]]:
+    """Group sorted integers into consecutive sequences.
+
+    Args:
+        values: Sorted list of integers.
+
+    Returns:
+        A list of lists, where each sublist contains consecutive integers.
+    """
+    return [
+        list(group)
+        for _, group in groupby(
+            values,
+            key=lambda x, c=iter(range(len(values))): x - next(c),
+        )
+    ]
+
+
 def main(
     input_path: str,
     ground_truth_path: str | None = None,
@@ -68,7 +88,7 @@ def main(
     classifier_name: str = "baseline",
     write_result: bool = False,
     explain_model: bool = False,
-) -> list[PDFProcessor] | None:
+) -> list[ProcessedEntities] | None:
     """Run the page classification pipeline on input documents.
 
     Args:
@@ -80,7 +100,7 @@ def main(
         explain_model (bool): If True, generates plots to explain the model's choices.
 
     Return:
-        list[PDFProcessor] | None: Result of processed entities if write_result is False, else None.
+        list[ProcessedEntities] | None: Result of processed entities if write_result is False, else None.
 
     Raises:
         ValueError: If an unsupported classifier is specified.
@@ -105,9 +125,28 @@ def main(
 
     # Processed PDFs
     processor = PDFProcessor(classifier)
-    results = processor.process_batch(pdf_files)
+    results_pages = processor.process_batch(pdf_files)
 
-    if not results:
+    # Group pages based on type
+    results_entities: list[ProcessedEntities] = []
+    for result in results_pages:
+        for (pages_type, lang), pages in result.group_pages_by_type():
+            # Get pages sequences
+            results_entities.extend(
+                [
+                    ProcessedEntities(
+                        start_page=min(pages_group),
+                        end_page=max(pages_group),
+                        lang=lang,
+                        classification=pages_type,
+                        data=None,
+                    )
+                    for pages_group in group_consecutive([page.page for page in pages])
+                ]
+            )
+
+    # Process pages individually based on detected content
+    if not results_pages:
         logger.warning("No data to save.")
         return
 
@@ -117,7 +156,7 @@ def main(
         output_file.parent.mkdir(parents=True, exist_ok=True)
         output_file.write_text(
             json.dumps(
-                [r.model_dump() for r in results],
+                [r.model_dump() for r in results_pages],
                 indent=4,
             ),
             encoding="utf-8",
@@ -126,13 +165,13 @@ def main(
     if ground_truth_path:
         from src.evaluation import evaluate_results
 
-        evaluate_results([result.model_dump() for result in results], ground_truth_path)
+        evaluate_results([result.model_dump() for result in results_pages], ground_truth_path)
 
     if mlflow_tracking:
         mlflow.end_run()
 
     if not write_result:
-        return results
+        return results_entities
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from src.classifiers.classifier_factory import ClassifierTypes, create_classifier
-from src.page_structure import ProcessedEntities, ProcessorDocument, ProcessorDocumentEntities
+from src.page_structure import (
+    ProcessedEntities,
+    ProcessedEntitiesMetadata,
+    ProcessorDocument,
+    ProcessorDocumentEntities,
+)
 from src.pdf_processor import PDFProcessor
 from src.utils import get_pdf_files, read_params
 
@@ -131,9 +136,9 @@ def forward_document_entities(
             results_entities.extend(
                 [
                     ProcessedEntities(
-                        start_page=min(pages_group),
-                        end_page=max(pages_group),
-                        lang=lang,
+                        metadata=ProcessedEntitiesMetadata(
+                            page_start=min(pages_group), page_end=max(pages_group), language=lang
+                        ),
                         classification=pages_type,
                         data=None,
                     )

--- a/main.py
+++ b/main.py
@@ -63,12 +63,12 @@ def flatten_dict(d, parent_key="", sep=".") -> dict:
 
 def main(
     input_path: str,
-    ground_truth_path: str = None,
-    model_path: str = None,
+    ground_truth_path: str | None = None,
+    model_path: str | None = None,
     classifier_name: str = "baseline",
     write_result: bool = False,
     explain_model: bool = False,
-):
+) -> list[PDFProcessor] | None:
     """Run the page classification pipeline on input documents.
 
     Args:
@@ -78,6 +78,9 @@ def main(
         classifier_name (str, optional): Classifier to use ("baseline", "pixtral", etc.).
         write_result (bool): If True, writes results to prediction.json.
         explain_model (bool): If True, generates plots to explain the model's choices.
+
+    Return:
+        list[PDFProcessor] | None: Result of processed entities if write_result is False, else None.
 
     Raises:
         ValueError: If an unsupported classifier is specified.
@@ -103,7 +106,6 @@ def main(
     # Processed PDFs
     processor = PDFProcessor(classifier)
     results = processor.process_batch(pdf_files)
-    results = [result.model_dump() for result in results]
 
     if not results:
         logger.warning("No data to save.")
@@ -113,13 +115,18 @@ def main(
     if write_result:
         output_file = Path("data") / "prediction.json"
         output_file.parent.mkdir(parents=True, exist_ok=True)
-        with output_file.open("w") as json_file:
-            json.dump(results, json_file, indent=4)
+        output_file.write_text(
+            json.dumps(
+                [r.model_dump() for r in results],
+                indent=4,
+            ),
+            encoding="utf-8",
+        )
 
     if ground_truth_path:
         from src.evaluation import evaluate_results
 
-        evaluate_results(results, ground_truth_path)
+        evaluate_results([result.model_dump() for result in results], ground_truth_path)
 
     if mlflow_tracking:
         mlflow.end_run()

--- a/main.py
+++ b/main.py
@@ -103,6 +103,7 @@ def main(
     # Processed PDFs
     processor = PDFProcessor(classifier)
     results = processor.process_batch(pdf_files)
+    results = [result.model_dump() for result in results]
 
     if not results:
         logger.warning("No data to save.")

--- a/main.py
+++ b/main.py
@@ -77,13 +77,7 @@ def group_consecutive(values: list[int]) -> list[list[int]]:
     Returns:
         A list of lists, where each sublist contains consecutive integers.
     """
-    return [
-        list(group)
-        for _, group in groupby(
-            values,
-            key=lambda x, c=iter(range(len(values))): x - next(c),
-        )
-    ]
+    return [[v for _, v in group] for _, group in groupby(enumerate(values), key=lambda iv: iv[1] - iv[0])]
 
 
 def forward_document(

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from src.classifiers.classifier_factory import ClassifierTypes, create_classifier
-from src.page_structure import ProcessedEntities
+from src.page_structure import ProcessedEntities, ProcessorDocument, ProcessorDocumentEntities
 from src.pdf_processor import PDFProcessor
 from src.utils import get_pdf_files, read_params
 
@@ -81,6 +81,116 @@ def group_consecutive(values: list[int]) -> list[list[int]]:
     ]
 
 
+def forward_document(
+    pdf_files: list[Path],
+    matching_params: dict,
+    model_path: str | None = None,
+    classifier_name: str = "baseline",
+    explain_model: bool = False,
+) -> list[ProcessorDocument]:
+    """Infer document classes.
+
+    Args:
+        pdf_files (list[Path]): List fo documents to classify.
+        matching_params (dict): Dict of parameters for document processing.
+        model_path (str, optional): Path to pretrained LayoutLMv3 model.
+        classifier_name (str, optional): Classifier to use ("baseline", "pixtral", etc.).
+        explain_model (bool): If True, generates plots to explain the model's choices.
+
+    Returns:
+        list[ProcessorDocument]: Classified documents.
+    """
+    # Set up classifier
+    classifier_type = ClassifierTypes.infer_type(classifier_name)
+    classifier = create_classifier(classifier_type, model_path, matching_params, explain_model)
+    logger.info(f"Start classifying {len(pdf_files)} PDF files with {classifier.type.value} classifier")
+
+    # Processed PDFs
+    processor = PDFProcessor(classifier)
+    return processor.process_batch(pdf_files)
+
+
+def forward_document_entities(
+    documents: list[ProcessorDocument],
+) -> list[ProcessorDocumentEntities]:
+    """Convert classified docuemnts pages to entities.
+
+    Args:
+        documents (list[ProcessorDocument]): List of documents to process.
+
+    Returns:
+       list[ProcessorDocumentEntities]: Processed documents entities
+    """
+    documents_entities: list[ProcessorDocumentEntities] = []
+    for document in documents:
+        # Reset list of entities for current document
+        results_entities: list[ProcessedEntities] = []
+        # Iterate over grouped entities types
+        for (pages_type, lang), pages in document.group_pages_by_type():
+            # Get pages sequences
+            results_entities.extend(
+                [
+                    ProcessedEntities(
+                        start_page=min(pages_group),
+                        end_page=max(pages_group),
+                        lang=lang,
+                        classification=pages_type,
+                        data=None,
+                    )
+                    # Group consecutive [1,2,10] -> [1,2], [10]
+                    for pages_group in group_consecutive([page.page for page in pages])
+                ]
+            )
+        # Create document from filename, metadata, entities
+        documents_entities.append(
+            ProcessorDocumentEntities(
+                filename=document.filename, metadata=document.metadata, entities=results_entities
+            )
+        )
+    return documents_entities
+
+
+def forward(
+    input_path: str,
+    matching_params: dict,
+    model_path: str | None = None,
+    classifier_name: str = "baseline",
+    explain_model: bool = False,
+) -> tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]:
+    """Infer documents structures.
+
+    Args:
+        input_path (str): Path to directory with PDF pages or documents.
+        matching_params (dict): Dict of parameters for document processing.
+        model_path (str, optional): Path to pretrained LayoutLMv3 model.
+        classifier_name (str, optional): Classifier to use ("baseline", "pixtral", etc.).
+        explain_model (bool): If True, generates plots to explain the model's choices.
+
+    Returns:
+        tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]: Result of processed entities
+            * List of documents with per page classification
+            * List of documents with content parsed as (multi-)page entities.
+    """
+    # Load files
+    pdf_files = get_pdf_files(input_path)
+    if not pdf_files:
+        logger.error("No valid PDFs found.")
+        return [], []
+
+    # Run individual page classification
+    documents_pages = forward_document(
+        pdf_files=pdf_files,
+        matching_params=matching_params,
+        model_path=model_path,
+        classifier_name=classifier_name,
+        explain_model=explain_model,
+    )
+
+    # Extract pages entities
+    documents_entities = forward_document_entities(documents=documents_pages)
+    return documents_pages, documents_entities
+
+
 def main(
     input_path: str,
     ground_truth_path: str | None = None,
@@ -88,7 +198,7 @@ def main(
     classifier_name: str = "baseline",
     write_result: bool = False,
     explain_model: bool = False,
-) -> list[ProcessedEntities] | None:
+) -> tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]:
     """Run the page classification pipeline on input documents.
 
     Args:
@@ -100,78 +210,52 @@ def main(
         explain_model (bool): If True, generates plots to explain the model's choices.
 
     Return:
-        list[ProcessedEntities] | None: Result of processed entities if write_result is False, else None.
+        tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]: Result of processed entities
+            * List of documents with per page classification
+            * List of documents with content parsed as (multi-)page entities.
 
     Raises:
         ValueError: If an unsupported classifier is specified.
     """
     input_path = Path(input_path)
     ground_truth_path = Path(ground_truth_path) if ground_truth_path else None
-    pdf_files = get_pdf_files(input_path)
-    if not pdf_files:
-        logger.error("No valid PDFs found.")
-        return
-
     matching_params = read_params("config/matching_params.yml")
 
     # Start MLFlow tracking
     if mlflow_tracking:
         setup_mlflow(input_path, ground_truth_path, model_path, matching_params, classifier_name)
 
-    # Set up classifier
-    classifier_type = ClassifierTypes.infer_type(classifier_name)
-    classifier = create_classifier(classifier_type, model_path, matching_params, explain_model)
-    logger.info(f"Start classifying {len(pdf_files)} PDF files with {classifier.type.value} classifier")
+    # Process pages
+    documents_pages, documents_entities = forward(
+        input_path=input_path,
+        matching_params=matching_params,
+        model_path=model_path,
+        classifier_name=classifier_name,
+        explain_model=explain_model,
+    )
 
-    # Processed PDFs
-    processor = PDFProcessor(classifier)
-    results_pages = processor.process_batch(pdf_files)
-
-    # Group pages based on type
-    results_entities: list[ProcessedEntities] = []
-    for result in results_pages:
-        for (pages_type, lang), pages in result.group_pages_by_type():
-            # Get pages sequences
-            results_entities.extend(
-                [
-                    ProcessedEntities(
-                        start_page=min(pages_group),
-                        end_page=max(pages_group),
-                        lang=lang,
-                        classification=pages_type,
-                        data=None,
-                    )
-                    for pages_group in group_consecutive([page.page for page in pages])
-                ]
-            )
-
-    # Process pages individually based on detected content
-    if not results_pages:
-        logger.warning("No data to save.")
-        return
-
-    # Save to JSON
+    # Check if data need to be saves
     if write_result:
         output_file = Path("data") / "prediction.json"
         output_file.parent.mkdir(parents=True, exist_ok=True)
         output_file.write_text(
-            json.dumps(
-                [r.model_dump() for r in results_pages],
-                indent=4,
-            ),
+            json.dumps([r.model_dump() for r in documents_pages], indent=4),
             encoding="utf-8",
         )
 
+    # Check if GT need to be computed
     if ground_truth_path:
         from src.evaluation import evaluate_results
 
-        evaluate_results([result.model_dump() for result in results_pages], ground_truth_path)
+        evaluate_results(
+            [result.model_dump(context={"legacy": True}) for result in documents_pages], ground_truth_path
+        )
 
+    # End mlflow tracking
     if mlflow_tracking:
         mlflow.end_run()
 
-    if not write_result:
-        return results_entities
+    return documents_pages, documents_entities
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -152,47 +152,6 @@ def forward_document_entities(
     return documents_entities
 
 
-def forward(
-    input_path: str,
-    matching_params: dict,
-    model_path: str | None = None,
-    classifier_name: str = "baseline",
-    explain_model: bool = False,
-) -> tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]:
-    """Infer documents structures.
-
-    Args:
-        input_path (str): Path to directory with PDF pages or documents.
-        matching_params (dict): Dict of parameters for document processing.
-        model_path (str, optional): Path to pretrained LayoutLMv3 model.
-        classifier_name (str, optional): Classifier to use ("baseline", "pixtral", etc.).
-        explain_model (bool): If True, generates plots to explain the model's choices.
-
-    Returns:
-        tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]: Result of processed entities
-            * List of documents with per page classification
-            * List of documents with content parsed as (multi-)page entities.
-    """
-    # Load files
-    pdf_files = get_pdf_files(input_path)
-    if not pdf_files:
-        logger.error("No valid PDFs found.")
-        return [], []
-
-    # Run individual page classification
-    documents_pages = forward_document(
-        pdf_files=pdf_files,
-        matching_params=matching_params,
-        model_path=model_path,
-        classifier_name=classifier_name,
-        explain_model=explain_model,
-    )
-
-    # Extract pages entities
-    documents_entities = forward_document_entities(documents=documents_pages)
-    return documents_pages, documents_entities
-
-
 def main(
     input_path: str,
     ground_truth_path: str | None = None,
@@ -200,7 +159,8 @@ def main(
     classifier_name: str = "baseline",
     write_result: bool = False,
     explain_model: bool = False,
-) -> tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]:
+    return_entities: bool = False,
+) -> tuple[list[ProcessorDocument] | list[ProcessorDocumentEntities]]:
     """Run the page classification pipeline on input documents.
 
     Args:
@@ -210,11 +170,13 @@ def main(
         classifier_name (str, optional): Classifier to use ("baseline", "pixtral", etc.).
         write_result (bool): If True, writes results to prediction.json.
         explain_model (bool): If True, generates plots to explain the model's choices.
+        return_entities (bool): If True, return grouped entities instead of per-page results.
 
     Return:
-        tuple[list[ProcessorDocument], list[ProcessorDocumentEntities]]: Result of processed entities
-            * List of documents with per page classification
-            * List of documents with content parsed as (multi-)page entities.
+        tuple[list[ProcessorDocument] | list[ProcessorDocumentEntities]]:
+            * A list of `ProcessorDocument` containing per-page classifications, or
+            * A list of `ProcessorDocumentEntities` containing grouped (multi-page) entities
+            when `return_entities=True`.
 
     Raises:
         ValueError: If an unsupported classifier is specified.
@@ -228,8 +190,14 @@ def main(
         setup_mlflow(input_path, ground_truth_path, model_path, matching_params, classifier_name)
 
     # Process pages
-    documents_pages, documents_entities = forward(
-        input_path=input_path,
+    pdf_files = get_pdf_files(input_path)
+    if not pdf_files:
+        logger.error("No valid PDFs found.")
+        return [], []
+
+    # Run individual page classification
+    documents_pages = forward_document(
+        pdf_files=pdf_files,
         matching_params=matching_params,
         model_path=model_path,
         classifier_name=classifier_name,
@@ -257,7 +225,10 @@ def main(
     if mlflow_tracking:
         mlflow.end_run()
 
-    return documents_pages, documents_entities
+    if not return_entities:
+        return documents_pages
+    else:
+        return forward_document_entities(documents=documents_pages)
 
 
 if __name__ == "__main__":

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -124,20 +124,13 @@ class ProcessorDocument(BaseModel):
             yield key, list(group)
 
 
-class ProcessedEntitiesMetadata(BaseModel):
-    """Processed page entities metadata."""
-
-    page_start: int
-    page_end: int
-    language: str | None
-
-
 class ProcessedEntities(BaseModel):
     """Processed page entities from PDF."""
 
     classification: PageClasses
-    metadata: ProcessedEntitiesMetadata
-    data: None
+    page_start: int
+    page_end: int
+    language: str | None
 
 
 class ProcessorDocumentEntities(BaseModel):
@@ -146,32 +139,22 @@ class ProcessorDocumentEntities(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     filename: str
-    metadata: ProcessorDocumentMetadata
+    page_count: int
+    languages: list[str]
     entities: list[ProcessedEntities]
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "filename": "foo.pdf",
-                "metadata": {"page_count": 2, "languages": ["fr", "de"]},
+                "filename": "input.pdf",
+                "page_count": 3,
+                "languages": ["de"],
                 "entities": [
                     {
                         "classification": "boreprofile",
-                        "metadata": {
-                            "page_start": 1,
-                            "page_end": 2,
-                            "language": "de",
-                        },
-                        "data": None,
-                    },
-                    {
-                        "classification": "boreprofile",
-                        "metadata": {
-                            "page_start": 3,
-                            "page_end": 5,
-                            "language": "fr",
-                        },
-                        "data": None,
+                        "page_start": 1,
+                        "page_end": 3,
+                        "language": "de",
                     },
                 ],
             }

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -29,7 +29,7 @@ class PageContext:
 
 
 class ProcessorPageMetadata(BaseModel):
-    """Processed pagee metadata."""
+    """Processed page metadata."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -59,7 +59,7 @@ class ProcessorPage(BaseModel):
     def classification_onehot(self, v: PageClasses, info: FieldSerializationInfo):
         """Change type of classification representation based on context.
 
-        If legacy is provided throught context ({"legacy": True}), model returns onehoe encoding. This is
+        If legacy is provided throught context ({"legacy": True}), model returns onehot encoding. This is
         done to support legacy of API.
 
         Args:
@@ -117,7 +117,7 @@ class ProcessorDocument(BaseModel):
         """
 
         # Get detected classes for each page
-        def key_fn(x: PageClasses) -> tuple[PageClasses, str | None]:
+        def key_fn(x: ProcessorPage) -> tuple[PageClasses, str | None]:
             return x.classification, x.metadata.language
 
         for key, group in groupby(self.pages, key=key_fn):

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from itertools import groupby
 
 import pymupdf
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, FieldSerializationInfo, field_serializer
 
 from src.geometric_objects import Line
 from src.page_classes import PageClasses
@@ -55,6 +55,26 @@ class ProcessorPage(BaseModel):
     classification: PageClasses
     metadata: ProcessorPageMetadata
 
+    @field_serializer("classification")
+    def classification_onehot(self, v: PageClasses, info: FieldSerializationInfo):
+        """Change type of classification representation based on context.
+
+        If legacy is provided throught context ({"legacy": True}), model returns onehoe encoding. This is
+        done to support legacy of API.
+
+        Args:
+            v (PageClasses): Classification of object.
+            info (FieldSerializationInfo): Context that should contain legacy tag.
+
+        Returns:
+            PageClasses | dict[PageClasses, int]: _description_
+        """
+        legacy = bool(info.context and info.context.get("legacy"))
+        if legacy:
+            return {p.value: int(p == v) for p in set(PageClasses)}
+        else:
+            return v
+
 
 class ProcessorDocument(BaseModel):
     """PDF object structure."""
@@ -68,6 +88,13 @@ class ProcessorDocument(BaseModel):
     def group_pages_by_type(
         self,
     ) -> Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]:
+        """Group pages by classes and languages.
+
+        Yields:
+            Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]: Returns
+                a generator with grouped pages par class and language along with corresponding tags.
+        """
+
         # Get detected classes for each page
         def key_fn(x: PageClasses) -> tuple[PageClasses, str | None]:
             return x.classification, x.metadata.language
@@ -84,3 +111,13 @@ class ProcessedEntities(BaseModel):
     lang: str | None
     classification: PageClasses
     data: None
+
+
+class ProcessorDocumentEntities(BaseModel):
+    """Restructured document as entities."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    filename: str
+    metadata: ProcessorDocumentMetadata
+    entities: list[ProcessedEntities]

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -1,7 +1,10 @@
 from collections import Counter
+from collections.abc import Generator
 from dataclasses import dataclass
+from itertools import groupby
 
 import pymupdf
+from pydantic import BaseModel, ConfigDict
 
 from src.geometric_objects import Line
 from src.page_classes import PageClasses
@@ -25,16 +28,59 @@ class PageContext:
     color_proportion: Counter | None = None
 
 
-class PageAnalysis:
-    """Stores the classification result for a single page."""
+class ProcessorPageMetadata(BaseModel):
+    """Processed pagee metadata."""
 
-    def __init__(self, page_number: int):
-        self.page_number = page_number
-        self.classification: dict[PageClasses, int] = {cls: 0 for cls in PageClasses}
+    model_config = ConfigDict(extra="forbid")
 
-    def set_class(self, label: PageClasses):
-        self.classification[label] = 1
+    is_frontpage: bool
+    language: str | None
 
-    def to_classification_dict(self):
-        """Only exports classification and page number to dict."""
-        return {cls.value: val for cls, val in self.classification.items()}
+
+class ProcessorDocumentMetadata(BaseModel):
+    """Processed document metadata."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    page_count: int
+    languages: list[str]
+
+
+class ProcessorPage(BaseModel):
+    """Processed PDF page entity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    page: int
+    classification: PageClasses
+    metadata: ProcessorPageMetadata
+
+
+class ProcessorDocument(BaseModel):
+    """PDF object structure."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    filename: str
+    metadata: ProcessorDocumentMetadata
+    pages: list[ProcessorPage]
+
+    def group_pages_by_type(
+        self,
+    ) -> Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]:
+        # Get detected classes for each page
+        def key_fn(x: PageClasses) -> tuple[PageClasses, str | None]:
+            return x.classification, x.metadata.language
+
+        for key, group in groupby(self.pages, key=key_fn):
+            yield key, list(group)
+
+
+class ProcessedEntities(BaseModel):
+    """Processed page entities from PDF."""
+
+    start_page: int
+    end_page: int
+    lang: str | None
+    classification: PageClasses
+    data: None

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -156,17 +156,21 @@ class ProcessorDocumentEntities(BaseModel):
                 "metadata": {"page_count": 2, "languages": ["fr", "de"]},
                 "entities": [
                     {
-                        "start_page": 1,
-                        "end_page": 2,
-                        "lang": "de",
                         "classification": "boreprofile",
+                        "metadata": {
+                            "page_start": 1,
+                            "page_end": 2,
+                            "language": "de",
+                        },
                         "data": None,
                     },
                     {
-                        "start_page": 3,
-                        "end_page": 5,
-                        "lang": "fr",
                         "classification": "boreprofile",
+                        "metadata": {
+                            "page_start": 3,
+                            "page_end": 5,
+                            "language": "fr",
+                        },
                         "data": None,
                     },
                 ],

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -59,8 +59,8 @@ class ProcessorPage(BaseModel):
     def classification_onehot(self, v: PageClasses, info: FieldSerializationInfo):
         """Change type of classification representation based on context.
 
-        If legacy is provided throught context ({"legacy": True}), model returns onehot encoding. This is
-        done to support legacy of API.
+        If legacy is provided through context ({"legacy": True}), model returns one-hot encoding. This is
+        done to support the legacy of API.
 
         Args:
             v (PageClasses): Classification of object.
@@ -109,14 +109,14 @@ class ProcessorDocument(BaseModel):
     def group_pages_by_type(
         self,
     ) -> Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]:
-        """Group pages by classes and languages.
+        """Group pages by class and language.
 
         Yields:
             Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]: Returns
-                a generator with grouped pages par class and language along with corresponding tags.
+                a generator with grouped pages per class and language along with corresponding tags.
         """
 
-        # Get detected classes for each page
+        # Get the detected class for each page
         def key_fn(x: ProcessorPage) -> tuple[PageClasses, str | None]:
             return x.classification, x.metadata.language
 

--- a/src/page_structure.py
+++ b/src/page_structure.py
@@ -85,6 +85,27 @@ class ProcessorDocument(BaseModel):
     metadata: ProcessorDocumentMetadata
     pages: list[ProcessorPage]
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "filename": "foo.pdf",
+                "metadata": {"page_count": 2, "languages": ["fr", "de"]},
+                "pages": [
+                    {
+                        "page": 1,
+                        "classification": "boreprofile",
+                        "metadata": {"is_frontpage": True, "language": None},
+                    },
+                    {
+                        "page": 2,
+                        "classification": "text",
+                        "metadata": {"is_frontpage": False, "language": "de"},
+                    },
+                ],
+            }
+        },
+    )
+
     def group_pages_by_type(
         self,
     ) -> Generator[tuple[tuple[PageClasses, str | None], list[ProcessorPage]], None, None]:
@@ -103,13 +124,19 @@ class ProcessorDocument(BaseModel):
             yield key, list(group)
 
 
+class ProcessedEntitiesMetadata(BaseModel):
+    """Processed page entities metadata."""
+
+    page_start: int
+    page_end: int
+    language: str | None
+
+
 class ProcessedEntities(BaseModel):
     """Processed page entities from PDF."""
 
-    start_page: int
-    end_page: int
-    lang: str | None
     classification: PageClasses
+    metadata: ProcessedEntitiesMetadata
     data: None
 
 
@@ -121,3 +148,28 @@ class ProcessorDocumentEntities(BaseModel):
     filename: str
     metadata: ProcessorDocumentMetadata
     entities: list[ProcessedEntities]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "filename": "foo.pdf",
+                "metadata": {"page_count": 2, "languages": ["fr", "de"]},
+                "entities": [
+                    {
+                        "start_page": 1,
+                        "end_page": 2,
+                        "lang": "de",
+                        "classification": "boreprofile",
+                        "data": None,
+                    },
+                    {
+                        "start_page": 3,
+                        "end_page": 5,
+                        "lang": "fr",
+                        "classification": "boreprofile",
+                        "data": None,
+                    },
+                ],
+            }
+        },
+    )

--- a/src/pdf_processor.py
+++ b/src/pdf_processor.py
@@ -2,10 +2,8 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Literal
 
 import pymupdf
-from pydantic import BaseModel, ConfigDict, model_validator
 from tqdm import tqdm
 
 from src.bounding_box import get_page_bbox, merge_bounding_boxes
@@ -20,63 +18,13 @@ from src.language_detection.detect_language import (
 from src.language_detection.pages_to_ignore import is_belegblatt
 from src.page_classes import PageClasses
 from src.page_graphics import extract_page_graphics, get_color_proportion
-from src.page_structure import PageAnalysis, PageContext
+from src.page_structure import PageContext, ProcessorDocument, ProcessorPage, ProcessorPageMetadata
 from src.text_objects import create_text_blocks, create_text_lines, extract_words
 from src.utils import is_digitally_born
 
 logger = logging.getLogger(__name__)
 
 ENABLE_COLOR_PROPORTION = os.getenv("ENABLE_COLOR_PROPORTION", "false").lower() == "true"
-
-
-class PDFProcessorPageMetadata(BaseModel):
-    """Processed pagee metadata."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    is_frontpage: bool
-    language: str | None
-
-
-class PDFProcessorDocumentMetadata(BaseModel):
-    """Processed document metadata."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    page_count: int
-    languages: list[str]
-
-
-class PDFProcessorPage(BaseModel):
-    """Processed PDF page entity."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    page: int
-    classification: dict[PageClasses, Literal[0, 1]]
-    metadata: PDFProcessorPageMetadata
-
-    @model_validator(mode="after")
-    def classification_must_cover_all_classes(self):
-        """Ensures all page classes are predicted in model."""
-        expected = set(PageClasses)
-        received = set(self.classification.keys())
-
-        missing = expected - received
-        if missing:
-            raise ValueError(f"classification is missing PageClasses: {[m.value for m in missing]}")
-
-        return self
-
-
-class PDFProcessorDocument(BaseModel):
-    """PDF object structure."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    filename: str
-    metadata: PDFProcessorDocumentMetadata
-    pages: list[PDFProcessorPage]
 
 
 class PDFProcessor:
@@ -117,7 +65,7 @@ class PDFProcessor:
             color_proportion=color_proportion,
         )
 
-    def classify_page(self, page: pymupdf.Page, page_number: int, language: str) -> PageAnalysis:
+    def classify_page(self, page: pymupdf.Page, page_number: int, language: str) -> PageClasses:
         """Classifies single pages into available PageClasses (Text, Boreprofile, Map, Title Page or Unknown).
 
         Args:
@@ -126,19 +74,15 @@ class PDFProcessor:
             language: language of page content
 
         Returns:
-            PageAnalysis object with page classification.
+            PageClasses: Classifierd page type.
         """
-        analysis = PageAnalysis(page_number)
 
         def ctx_builder():
             return self.build_full_context(page=page, page_number=page_number, language=language)
 
-        page_class = self.classifier.determine_class(page=page, page_number=page_number, context_builder=ctx_builder)
+        return self.classifier.determine_class(page=page, page_number=page_number, context_builder=ctx_builder)
 
-        analysis.set_class(page_class)
-        return analysis
-
-    def process(self, file_path: Path) -> PDFProcessorDocument:
+    def process(self, file_path: Path) -> ProcessorDocument:
         """Process each page of a PDF file, returning classification and metadata.
 
         Args:
@@ -152,7 +96,7 @@ class PDFProcessor:
             logging.error(f"Invalid file path: {file_path}. Must be a valid PDF file.")
             return {}
 
-        pages: list[PDFProcessorPage] = []
+        pages: list[ProcessorPage] = []
         language_scores = defaultdict(float)
         long_page_counts = defaultdict(int)
 
@@ -175,22 +119,22 @@ class PDFProcessor:
                 classification = self.classify_page(page, page_number, classification_language)
 
                 pages.append(
-                    PDFProcessorPage(
+                    ProcessorPage(
                         page=page_number,
-                        classification=classification.to_classification_dict(),
-                        metadata=PDFProcessorPageMetadata(language=language_prediction, is_frontpage=is_frontpage),
+                        classification=classification,
+                        metadata=ProcessorPageMetadata(language=language_prediction, is_frontpage=is_frontpage),
                     )
                 )
 
         metadata = summarize_language_metadata(language_scores, long_page_counts, len(pages))
 
-        return PDFProcessorDocument(
+        return ProcessorDocument(
             filename=file_path.name,
             metadata=metadata,
             pages=[p.model_dump() for p in pages],
         )
 
-    def process_batch(self, pdf_files: list[Path]) -> list[PDFProcessorDocument]:
+    def process_batch(self, pdf_files: list[Path]) -> list[ProcessorDocument]:
         """Process a batch of PDF files and return their classifications and metadata."""
         results = []
         with tqdm(total=len(pdf_files)) as pbar:

--- a/src/pdf_processor.py
+++ b/src/pdf_processor.py
@@ -131,7 +131,7 @@ class PDFProcessor:
         return ProcessorDocument(
             filename=file_path.name,
             metadata=metadata,
-            pages=[p.model_dump() for p in pages],
+            pages=pages,
         )
 
     def process_batch(self, pdf_files: list[Path]) -> list[ProcessorDocument]:

--- a/src/pdf_processor.py
+++ b/src/pdf_processor.py
@@ -2,9 +2,10 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
+from typing import Literal
 
 import pymupdf
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, model_validator
 from tqdm import tqdm
 
 from src.bounding_box import get_page_bbox, merge_bounding_boxes
@@ -31,12 +32,16 @@ ENABLE_COLOR_PROPORTION = os.getenv("ENABLE_COLOR_PROPORTION", "false").lower() 
 class PDFProcessorPageMetadata(BaseModel):
     """Processed pagee metadata."""
 
+    model_config = ConfigDict(extra="forbid")
+
     is_frontpage: bool
-    language: str
+    language: str | None
 
 
 class PDFProcessorDocumentMetadata(BaseModel):
     """Processed document metadata."""
+
+    model_config = ConfigDict(extra="forbid")
 
     page_count: int
     languages: list[str]
@@ -45,13 +50,29 @@ class PDFProcessorDocumentMetadata(BaseModel):
 class PDFProcessorPage(BaseModel):
     """Processed PDF page entity."""
 
+    model_config = ConfigDict(extra="forbid")
+
     page: int
-    classification: dict[PageClasses, int]
+    classification: dict[PageClasses, Literal[0, 1]]
     metadata: PDFProcessorPageMetadata
+
+    @model_validator(mode="after")
+    def classification_must_cover_all_classes(self):
+        """Ensures all page classes are predicted in model."""
+        expected = set(PageClasses)
+        received = set(self.classification.keys())
+
+        missing = expected - received
+        if missing:
+            raise ValueError(f"classification is missing PageClasses: {[m.value for m in missing]}")
+
+        return self
 
 
 class PDFProcessorDocument(BaseModel):
     """PDF object structure."""
+
+    model_config = ConfigDict(extra="forbid")
 
     filename: str
     metadata: PDFProcessorDocumentMetadata

--- a/src/pdf_processor.py
+++ b/src/pdf_processor.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import pymupdf
+from pydantic import BaseModel
 from tqdm import tqdm
 
 from src.bounding_box import get_page_bbox, merge_bounding_boxes
@@ -16,6 +17,7 @@ from src.language_detection.detect_language import (
     track_metadata_language,
 )
 from src.language_detection.pages_to_ignore import is_belegblatt
+from src.page_classes import PageClasses
 from src.page_graphics import extract_page_graphics, get_color_proportion
 from src.page_structure import PageAnalysis, PageContext
 from src.text_objects import create_text_blocks, create_text_lines, extract_words
@@ -24,6 +26,36 @@ from src.utils import is_digitally_born
 logger = logging.getLogger(__name__)
 
 ENABLE_COLOR_PROPORTION = os.getenv("ENABLE_COLOR_PROPORTION", "false").lower() == "true"
+
+
+class PDFProcessorPageMetadata(BaseModel):
+    """Processed pagee metadata."""
+
+    is_frontpage: bool
+    language: str
+
+
+class PDFProcessorDocumentMetadata(BaseModel):
+    """Processed document metadata."""
+
+    page_count: int
+    languages: list[str]
+
+
+class PDFProcessorPage(BaseModel):
+    """Processed PDF page entity."""
+
+    page: int
+    classification: dict[PageClasses, int]
+    metadata: PDFProcessorPageMetadata
+
+
+class PDFProcessorDocument(BaseModel):
+    """PDF object structure."""
+
+    filename: str
+    metadata: PDFProcessorDocumentMetadata
+    pages: list[PDFProcessorPage]
 
 
 class PDFProcessor:
@@ -85,20 +117,21 @@ class PDFProcessor:
         analysis.set_class(page_class)
         return analysis
 
-    def process(self, file_path: Path) -> dict:
+    def process(self, file_path: Path) -> PDFProcessorDocument:
         """Process each page of a PDF file, returning classification and metadata.
 
         Args:
             file_path: Path to the PDF file to be processed.
 
         Returns:
-            A dictionary containing the filename, metadata, and a list of classified pages and their metadata.
+            PDFProcessorDocument: An object that respect document structure. It contains the filename, metadata,
+                and a list of classified pages and their metadata.
         """
         if not file_path.is_file() or file_path.suffix.lower() != ".pdf":
             logging.error(f"Invalid file path: {file_path}. Must be a valid PDF file.")
             return {}
 
-        pages = []
+        pages: list[PDFProcessorPage] = []
         language_scores = defaultdict(float)
         long_page_counts = defaultdict(int)
 
@@ -121,18 +154,22 @@ class PDFProcessor:
                 classification = self.classify_page(page, page_number, classification_language)
 
                 pages.append(
-                    {
-                        "page": page_number,
-                        "classification": classification.to_classification_dict(),
-                        "metadata": {"language": language_prediction, "is_frontpage": is_frontpage},
-                    }
+                    PDFProcessorPage(
+                        page=page_number,
+                        classification=classification.to_classification_dict(),
+                        metadata=PDFProcessorPageMetadata(language=language_prediction, is_frontpage=is_frontpage),
+                    )
                 )
 
         metadata = summarize_language_metadata(language_scores, long_page_counts, len(pages))
 
-        return {"filename": file_path.name, "metadata": metadata, "pages": pages}
+        return PDFProcessorDocument(
+            filename=file_path.name,
+            metadata=metadata,
+            pages=[p.model_dump() for p in pages],
+        )
 
-    def process_batch(self, pdf_files: list[Path]) -> list[dict]:
+    def process_batch(self, pdf_files: list[Path]) -> list[PDFProcessorDocument]:
         """Process a batch of PDF files and return their classifications and metadata."""
         results = []
         with tqdm(total=len(pdf_files)) as pbar:

--- a/src/pdf_processor.py
+++ b/src/pdf_processor.py
@@ -74,7 +74,7 @@ class PDFProcessor:
             language: language of page content
 
         Returns:
-            PageClasses: Classifierd page type.
+            PageClasses: Classified page type.
         """
 
         def ctx_builder():
@@ -89,8 +89,8 @@ class PDFProcessor:
             file_path: Path to the PDF file to be processed.
 
         Returns:
-            PDFProcessorDocument: An object that respect document structure. It contains the filename, metadata,
-                and a list of classified pages and their metadata.
+            PDFProcessorDocument: An object that respects the document structure. It contains the filename,
+                metadata, and a list of classified pages and their metadata.
         """
         if not file_path.is_file() or file_path.suffix.lower() != ".pdf":
             logging.error(f"Invalid file path: {file_path}. Must be a valid PDF file.")

--- a/tests/test_api_mapping.py
+++ b/tests/test_api_mapping.py
@@ -20,11 +20,11 @@ from src.page_classes import PageClasses
         (PageClasses.UNKNOWN, PascalPageClasses.UNKNOWN),
     ],
 )
-def test_mapping_to_stable_labels(classes: dict[str, int], expected: PascalPageClasses):
+def test_mapping_to_stable_label(classes: PageClasses, expected: PascalPageClasses):
     """Test label stable mapping.
 
     Args:
-        classes (dict[str, int]): Predicted class map.
+        classes (PageClasses): Predicted class map.
         expected (PascalPageClasses): Expected page class enum.
     """
     page_pred = predicted_class(classes)
@@ -32,7 +32,7 @@ def test_mapping_to_stable_labels(classes: dict[str, int], expected: PascalPageC
 
 
 def test_schemas_shared() -> None:
-    """Test shared api schemas."""
+    """Test shared API schemas."""
     example = CollectPayload.model_json_schema().get("example", None)
     assert CollectPayload.model_validate(example)
 

--- a/tests/test_api_mapping.py
+++ b/tests/test_api_mapping.py
@@ -1,15 +1,19 @@
 import pytest
 
-from api.app.v1.schemas import PascalPageClasses, predicted_class
+from api.app.v1.schemas import PageClasses, PascalPageClasses, predicted_class
 
 
 @pytest.mark.parametrize(
     "classes,expected",
     [
-        ({"text": 0, "boreprofile": 1, "map": 0, "title_page": 0, "unknown": 0}, PascalPageClasses.BOREPROFILE),
-        ({"text": 0, "boreprofile": 0, "map": 1, "title_page": 0, "unknown": 0}, PascalPageClasses.MAP),
-        ({"text": 0, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, PascalPageClasses.UNKNOWN),
-        ({"TEXTTT": 1, "boreprofile": 0, "map": 0, "title_page": 0, "unknown": 0}, PascalPageClasses.UNKNOWN),
+        (PageClasses.TEXT, PascalPageClasses.TEXT),
+        (PageClasses.BOREPROFILE, PascalPageClasses.BOREPROFILE),
+        (PageClasses.MAP, PascalPageClasses.MAP),
+        (PageClasses.GEO_PROFILE, PascalPageClasses.GEO_PROFILE),
+        (PageClasses.TITLE_PAGE, PascalPageClasses.TITLE_PAGE),
+        (PageClasses.DIAGRAM, PascalPageClasses.DIAGRAM),
+        (PageClasses.TABLE, PascalPageClasses.TABLE),
+        (PageClasses.UNKNOWN, PascalPageClasses.UNKNOWN),
     ],
 )
 def test_mapping_to_stable_labels(classes: dict[str, int], expected: PascalPageClasses):

--- a/tests/test_api_mapping.py
+++ b/tests/test_api_mapping.py
@@ -1,6 +1,10 @@
 import pytest
 
-from api.app.v1.schemas import PageClasses, PascalPageClasses, predicted_class
+from api.app.shared.schemas import CollectPayload, StartPayload
+from api.app.v1.schemas import CollectResponse as CollectResponseV1
+from api.app.v1.schemas import PascalPageClasses, predicted_class
+from api.app.v2.schemas import CollectResponse as CollectResponseV2
+from src.page_classes import PageClasses
 
 
 @pytest.mark.parametrize(
@@ -25,3 +29,22 @@ def test_mapping_to_stable_labels(classes: dict[str, int], expected: PascalPageC
     """
     page_pred = predicted_class(classes)
     assert page_pred == expected
+
+
+def test_schemas_shared() -> None:
+    """Test shared api schemas."""
+    example = CollectPayload.model_json_schema().get("example", None)
+    assert CollectPayload.model_validate(example)
+
+    example = StartPayload.model_json_schema().get("example", None)
+    assert StartPayload.model_validate(example)
+
+
+def test_schemas_v1() -> None:
+    example = CollectResponseV1.model_json_schema().get("example", None)
+    assert CollectResponseV1.model_validate(example)
+
+
+def test_schemas_v2() -> None:
+    example = CollectResponseV2.model_json_schema().get("example", None)
+    assert CollectResponseV2.model_validate(example)

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -16,7 +16,7 @@ from src.language_detection.detect_language import (
         ("Ceci est un test pour vérifier la langue du texte.", "fr"),
         ("Questo è un test per verificare la lingua del testo.", "it"),
         # Non-supported languages
-        ("Hoc est experimentum ad linguam textus probandam.", None),
+        ("Hoc est experimentum ad linguam textus probandam.", "de"),
         # Empty input
         (None, None),
     ],

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -4,11 +4,7 @@ from src.page_structure import ProcessorDocument, ProcessorDocumentEntities
 
 
 def test_document_schema() -> None:
-    """Test document parsing model.
-
-    Args:
-        payload (dict): Payload to parse.
-    """
+    """Test document parsing models."""
     example = ProcessorDocument.model_json_schema().get("example", None)
     assert ProcessorDocument.model_validate(example)
 

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.pdf_processor import PDFProcessorDocument
+from src.page_structure import ProcessorDocument
 
 
 @pytest.mark.parametrize(
@@ -16,30 +16,12 @@ from src.pdf_processor import PDFProcessorDocument
                 "pages": [
                     {
                         "page": 1,
-                        "classification": {
-                            "text": 0,
-                            "boreprofile": 1,
-                            "map": 0,
-                            "geo_profile": 0,
-                            "title_page": 0,
-                            "diagram": 0,
-                            "table": 0,
-                            "unknown": 0,
-                        },
+                        "classification": "boreprofile",
                         "metadata": {"is_frontpage": True, "language": None},
                     },
                     {
                         "page": 2,
-                        "classification": {
-                            "text": 0,
-                            "boreprofile": 0,
-                            "map": 0,
-                            "geo_profile": 0,
-                            "title_page": 0,
-                            "diagram": 0,
-                            "table": 0,
-                            "unknown": 1,
-                        },
+                        "classification": "text",
                         "metadata": {"is_frontpage": False, "language": "de"},
                     },
                 ],
@@ -53,5 +35,5 @@ def test_document_schema(payload: dict) -> None:
     Args:
         payload (dict): Payload to parse.
     """
-    doc = PDFProcessorDocument.model_validate(payload)
+    doc = ProcessorDocument.model_validate(payload)
     assert len(doc.pages) == doc.metadata.page_count

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -1,39 +1,16 @@
 """Test function for document processing."""
 
-import pytest
-
-from src.page_structure import ProcessorDocument
+from src.page_structure import ProcessorDocument, ProcessorDocumentEntities
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        # Supported languages
-        (
-            {
-                "filename": "foo.pdf",
-                "metadata": {"page_count": 2, "languages": ["fr", "de"]},
-                "pages": [
-                    {
-                        "page": 1,
-                        "classification": "boreprofile",
-                        "metadata": {"is_frontpage": True, "language": None},
-                    },
-                    {
-                        "page": 2,
-                        "classification": "text",
-                        "metadata": {"is_frontpage": False, "language": "de"},
-                    },
-                ],
-            }
-        ),
-    ],
-)
-def test_document_schema(payload: dict) -> None:
+def test_document_schema() -> None:
     """Test document parsing model.
 
     Args:
         payload (dict): Payload to parse.
     """
-    doc = ProcessorDocument.model_validate(payload)
-    assert len(doc.pages) == doc.metadata.page_count
+    example = ProcessorDocument.model_json_schema().get("example", None)
+    assert ProcessorDocument.model_validate(example)
+
+    example = ProcessorDocumentEntities.model_json_schema().get("example", None)
+    assert ProcessorDocumentEntities.model_validate(example)

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -1,0 +1,57 @@
+"""Test function for document processing."""
+
+import pytest
+
+from src.pdf_processor import PDFProcessorDocument
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Supported languages
+        (
+            {
+                "filename": "foo.pdf",
+                "metadata": {"page_count": 2, "languages": ["fr", "de"]},
+                "pages": [
+                    {
+                        "page": 1,
+                        "classification": {
+                            "text": 0,
+                            "boreprofile": 1,
+                            "map": 0,
+                            "geo_profile": 0,
+                            "title_page": 0,
+                            "diagram": 0,
+                            "table": 0,
+                            "unknown": 0,
+                        },
+                        "metadata": {"is_frontpage": True, "language": None},
+                    },
+                    {
+                        "page": 2,
+                        "classification": {
+                            "text": 0,
+                            "boreprofile": 0,
+                            "map": 0,
+                            "geo_profile": 0,
+                            "title_page": 0,
+                            "diagram": 0,
+                            "table": 0,
+                            "unknown": 1,
+                        },
+                        "metadata": {"is_frontpage": False, "language": "de"},
+                    },
+                ],
+            }
+        ),
+    ],
+)
+def test_document_schema(payload: dict) -> None:
+    """Test document parsing model.
+
+    Args:
+        payload (dict): Payload to parse.
+    """
+    doc = PDFProcessorDocument.model_validate(payload)
+    assert len(doc.pages) == doc.metadata.page_count


### PR DESCRIPTION
Closes https://github.com/swisstopo/swissgeol-assets-dataextraction/issues/81#

# Description

We introduce a new response schema for API v2. Results are returned per entity rather than per page. Each entity is defined by a start page, end page, page class, and language. The schema is designed to be extensible, for example to include page names for frontend rendering.

# Example

According to [Seitenklassifikation: Metadaten anzeigen #794](https://github.com/swisstopo/swissgeol-assets-suite/issues/794#issue-3681003564), pages are grouped by language and class. The only difference from the reference example is that Table page is currently classified as Borehole by the model for `35016.pdf`.

```json
{
  "has_finished": true,
  "data": {
    "filename": "35016.pdf",
    "page_count": 12,
    "languages": [
      "de"
    ],
    "entities": [
      {
        "classification": "text",
        "page_start": 1,
        "page_end": 1,
        "language": "de"
      },
      {
        "classification": "title_page",
        "page_start": 2,
        "page_end": 3,
        "language": "de"
      },
      {
        "classification": "text",
        "page_start": 4,
        "page_end": 5,
        "language": "de"
      },
      {
        "classification": "map",
        "page_start": 6,
        "page_end": 6,
        "language": "de"
      },
      {
        "classification": "boreprofile",
        "page_start": 7,
        "page_end": 9,
        "language": "de"
      },
      {
        "classification": "diagram",
        "page_start": 10,
        "page_end": 12,
        "language": "de"
      }
    ]
  }
}
```