### PR TITLE
 Add deterministic dataset splitter

### DIFF
--- a/src/scripts/split_data.py
+++ b/src/scripts/split_data.py
@@ -1,55 +1,129 @@
-import random
+"""Split a directory of PDFs into train/validation/test using a deterministic hash."""
+
+import hashlib
+import logging
 import shutil
 from pathlib import Path
 
 import click
 
+logger = logging.getLogger(__name__)
 
-@click.command()
-@click.option("-i", "--input_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
-@click.option("-o", "--output_dir", type=click.Path(file_okay=False, path_type=Path))
-@click.option("--val-ratio", default=0.2, help="Proportion of validation set (default: 0.2)")
-@click.option("--seed", default=42, help="Random seed for reproducibility")
-def split_dataset(input_dir: Path, output_dir: Path, val_ratio: float, seed: int):
-    """Recursively splits PDFs in input_dir into flat train/val folders under OUTPUT_DIR.
 
-    It does not preserve original subdirectory structure.
+def deterministic_hash_ratio(text: str) -> float:
+    """Map a string deterministically to a float in [0, 1).
+
+    This is used to assign files to splits in a reproducible way, based only on
+    their filename (or any stable string key).
 
     Args:
-        input_dir: Directory containing PDF files to split.
-        output_dir: Directory where train/val folders will be created.
-        val_ratio: Proportion of files to use for validation (default: 0.2).
-        seed: Random seed for shuffling files (default: 42).
+        text: Input string to hash (e.g., a filename).
+
+    Returns:
+        A float in the half-open interval [0, 1).
     """
-    pdf_files = list(input_dir.rglob("*.pdf"))
-    if not pdf_files:
-        click.echo("No PDF files found in the input directory.")
+    h = hashlib.sha256(text.encode("utf-8")).digest()
+    # Use the first 8 bytes (64 bits) to build a stable ratio in [0, 1).
+    return int.from_bytes(h[:8], "big") / 2**64
+
+
+@click.command(help="Split PDFs into train/validation/test folders deterministically.")
+@click.option(
+    "-i",
+    "--input-directory",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Directory containing input *.pdf files (non-recursive).",
+)
+@click.option(
+    "-o",
+    "--output-directory",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Output directory where train/, validation/, and test/ will be created.",
+)
+@click.option(
+    "-rt",
+    "--rtest",
+    default=0.15,
+    show_default=True,
+    type=float,
+    help="Fraction of files assigned to the test split.",
+)
+@click.option(
+    "-rv",
+    "--rvalid",
+    default=0.15,
+    show_default=True,
+    type=float,
+    help="Fraction of files assigned to the validation split.",
+)
+def split_data(input_directory: Path, output_directory: Path, rtest: float, rvalid: float) -> None:
+    """Split PDF files into train/validation/test using filename hashing.
+
+    The split is deterministic: each file is assigned based on a hash of its
+    filename. This means adding new files later will **not** reshuffle existing
+    assignments (as long as filenames don’t change).
+
+    input_directory
+    ├── file_1.pdf
+    ├── ...
+    └── file_n.pdf
+
+    output_directory
+    ├── train
+    │   ├── file_1.pdf
+    │   └── ...
+    ├── validation
+    │   ├── file_2.pdf
+    │   └── ...
+    └── test
+        ├── file_3.pdf
+        └── ...
+
+    Args:
+        input_directory (Path): Folder containing the input PDF files.
+        output_directory (Path): Destination folder for the split subfolders.
+        rtest (float): Fraction assigned to the test set. Defaults to 0.15.
+        rvalid (float): Fraction assigned to the validation set. Defaults to 0.15.
+    """
+    # Check that valid and test are coherent
+    if rtest < 0 or rvalid < 0 or (rtest + rvalid) >= 1:
+        raise click.BadParameter("Require 0 <= rtest, rvalid and rtest + rvalid < 1.")
+
+    # Read input files and check if any
+    files = [p.name for p in input_directory.iterdir() if p.is_file() and p.suffix.lower() == ".pdf"]
+    if not files:
+        logger.info("No PDF files found in %s", input_directory)
         return
 
-    random.seed(seed)
-    random.shuffle(pdf_files)
+    # Get split into sets.
+    splits = {"train": [], "validation": [], "test": []}
+    for file in files:
+        x_ratio = deterministic_hash_ratio(file)
+        if x_ratio < rtest:
+            splits["test"].append(file)
+        elif x_ratio < rtest + rvalid:
+            splits["validation"].append(file)
+        else:
+            splits["train"].append(file)
 
-    n_val = int(len(pdf_files) * val_ratio)
-    val_files = pdf_files[:n_val]
-    train_files = pdf_files[n_val:]
+    logger.info(
+        "Files train: {}, validation: {}, test: {}".format(
+            len(splits["train"]), len(splits["validation"]), len(splits["test"])
+        )
+    )
 
-    train_dir = output_dir / "train"
-    val_dir = output_dir / "val"
-    for folder in [train_dir, val_dir]:
-        if folder.exists():
-            shutil.rmtree(folder)
-        folder.mkdir(parents=True)
+    # Prepare outputs
+    for split_name, split_files in splits.items():
+        # Create output directory
+        (output_directory / split_name).mkdir(parents=True, exist_ok=True)
+        # Write to output
+        for filename in split_files:
+            shutil.copyfile(input_directory / filename, output_directory / split_name / filename)
 
-    # Copy files flatly
-    for file in train_files:
-        shutil.copy2(file, train_dir / file.name)
-
-    for file in val_files:
-        shutil.copy2(file, val_dir / file.name)
-
-    print(f"Split {len(pdf_files)} files: {len(train_files)} train / {len(val_files)} val.")
-    print(f"Output saved to: {output_dir.resolve()}")
+    logger.info("Done.")
 
 
 if __name__ == "__main__":
-    split_dataset()
+    split_data()


### PR DESCRIPTION
closes https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/363

# Description
Add a script tool to split an input folder of *.pdf files into train/, validation/, and test/ directories using a deterministic hash-based split. The split must be stable across runs so adding new files does not reshuffle existing ones.

# Criteria

* Deterministic split based on filename hash
* Configurable rtest and rvalid ratios
* Creates train/, validation/, test folders
