### PR TITLE
Add uv dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ ignore = ["D102", "D105", "D107", "D100", "D103", "SIM108"]
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 # ---- Configuration for package building
 [tool.hatch.build.targets.wheel]
 packages = ["src"]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-03-23T11:12:06.620389Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "alembic"
 version = "1.18.4"
@@ -3064,9 +3068,9 @@ dependencies = [
     { name = "boto3-stubs", extra = ["s3", "textract"] },
     { name = "fastapi", extra = ["standard"] },
     { name = "joblib" },
+    { name = "levenshtein" },
     { name = "numpy" },
     { name = "opencv-python" },
-    { name = "pandas" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -3121,12 +3125,12 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.116.1" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.116.1" },
     { name = "joblib", specifier = ">=1.5.1,<2.0.0" },
+    { name = "levenshtein", specifier = "==0.27.1" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.3,<4.0.0" },
     { name = "mlflow", marker = "extra == 'dev'", specifier = ">=3.3.1,<4.0.0" },
     { name = "mlflow", marker = "extra == 'experiment-tracking'", specifier = ">=3.1.4,<4.0.0" },
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },
     { name = "opencv-python", specifier = ">=4.12.0.88,<5.0.0.0" },
-    { name = "pandas", specifier = ">=2.3.1,<3.0.0" },
     { name = "pillow", specifier = ">=11.3.0,<12.0.0" },
     { name = "pre-commit", marker = "extra == 'lint'", specifier = ">=4.2.0,<5.0.0" },
     { name = "pydantic", specifier = "==2.11.7" },


### PR DESCRIPTION
Closes #114 

Adds `exclude-newer = "7 days"` in `pyproject.toml`.

This prevents uv from resolving package versions published in the last 30 days, reducing supply chain risk by giving the community time to vet new releases.

